### PR TITLE
Rewrite skills for MCP-first tool access

### DIFF
--- a/.claude/skills/lifesciences-clinical/SKILL.md
+++ b/.claude/skills/lifesciences-clinical/SKILL.md
@@ -1,60 +1,86 @@
 ---
 name: lifesciences-clinical
-description: "Queries clinical databases (Open Targets, ClinicalTrials.gov) via curl for target-disease associations, target tractability assessment, and clinical trial discovery. This skill should be used when the user asks to \"validate drug targets\", \"find clinical trials\", \"assess target tractability\", \"discover disease associations\", or mentions Open Targets scores, NCT identifiers, target-disease evidence, druggability assessment, or translational research workflows."
+description: "Queries clinical databases (Open Targets, ClinicalTrials.gov) via MCP tools for target-disease associations, target tractability assessment, and clinical trial discovery. Falls back to curl when MCP is unavailable. This skill should be used when the user asks to \"validate drug targets\", \"find clinical trials\", \"assess target tractability\", \"discover disease associations\", or mentions Open Targets scores, NCT identifiers, target-disease evidence, druggability assessment, or translational research workflows."
 ---
 
 # Clinical & Translational API Skills
 
-Query clinical databases directly via curl. These endpoints complement the Life Sciences MCPs.
+Query clinical databases via MCP tools (primary) or curl (fallback).
 
-## Quick Reference
+## Grounding Rule
 
-| Task | API | Endpoint |
-|------|-----|----------|
-| Target-disease associations | Open Targets | GraphQL `/graphql` |
-| Target tractability | Open Targets | GraphQL `tractability` |
-| Known drugs for target | Open Targets | GraphQL `knownDrugs` |
-| Search clinical trials | ClinicalTrials.gov | `/studies` |
-| Get trial details | ClinicalTrials.gov | `/studies/{NCT}` |
+All target-disease associations, drug names, trial IDs, and clinical data MUST come from API results. Do NOT provide NCT IDs, trial statuses, or drug-disease associations from training knowledge. If a query returns no results, report "No results found."
 
-## Open Targets GraphQL
+## LOCATE → RETRIEVE Patterns
 
-Open Targets uses GraphQL - construct queries to get exactly what you need in one call.
+### Open Targets: Target-Disease Associations
 
-### Basic Target-Disease Associations
+**LOCATE**: Search for target or disease
 
+PRIMARY (MCP tool):
+```
+Call `opentargets_search_targets` with: {"query": "breast cancer"}
+→ Returns: target/disease IDs and names
+```
+
+FALLBACK (curl):
 ```bash
-# Get diseases associated with target (TP53)
+curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ search(queryString: \"breast cancer\", entityNames: [\"disease\"]) { hits { id name } } }"}' \
+  | jq '.data.search.hits[:3]'
+```
+
+**RETRIEVE**: Get diseases associated with target
+
+PRIMARY (MCP tool):
+```
+Call `opentargets_get_associations` with: {"ensembl_id": "ENSG00000141510"}
+→ Returns: associated diseases with scores and evidence types
+```
+
+FALLBACK (curl):
+```bash
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
   -d '{"query": "{ target(ensemblId: \"ENSG00000141510\") { approvedSymbol associatedDiseases(page: {index: 0, size: 5}) { rows { disease { id name } score } } } }"}' \
-  | jq '.data.target.associatedDiseases.rows[] | {disease: .disease.name, score}'
+  | jq '.data.target.associatedDiseases.rows[] | {disease: .disease.name, id: .disease.id, score}'
 ```
 
-### Target Details with Tractability
+### Open Targets: Target Tractability — curl only
 
+**RETRIEVE**: Get druggability assessment
 ```bash
-# Get target with druggability assessment
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
   -d '{"query": "{ target(ensemblId: \"ENSG00000141510\") { approvedSymbol biotype tractability { label modality value } } }"}' \
   | jq '.data.target | {symbol: .approvedSymbol, tractability}'
 ```
 
-### Known Drugs for Target
+### Open Targets: Known Drugs for Target
 
+**LOCATE**: Find approved drugs targeting a protein
+
+PRIMARY (MCP tool):
+```
+Call `opentargets_get_target` with: {"ensembl_id": "ENSG00000171791"}
+→ Returns: knownDrugs with drug name, phase, mechanismOfAction
+```
+
+FALLBACK (curl):
 ```bash
-# Get approved drugs targeting a protein
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { approvedSymbol knownDrugs(page: {size: 5}) { rows { drug { name } phase mechanismOfAction } } } }"}' \
+  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { approvedSymbol knownDrugs(page: {index: 0, size: 5}) { rows { drug { name id } phase mechanismOfAction } } } }"}' \
   | jq '.data.target.knownDrugs.rows[] | {drug: .drug.name, phase, mechanism: .mechanismOfAction}'
 ```
 
-### Nested Query: All-in-One
+**Note**: Always include `index: 0` in pagination — omitting it causes errors.
 
+### Open Targets: All-in-One Nested Query — curl only
+
+**RETRIEVE**: Get target + diseases + drugs + tractability in single call
 ```bash
-# Get target + diseases + drugs + tractability in single call
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
   -d '{
@@ -63,69 +89,82 @@ curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
         approvedSymbol
         biotype
         tractability { label value }
-        knownDrugs(page: {size: 3}) {
-          rows { drug { name } phase }
+        knownDrugs(page: {index: 0, size: 3}) {
+          rows { drug { name } phase mechanismOfAction }
         }
-        associatedDiseases(page: {size: 3}) {
-          rows { disease { name } score }
+        associatedDiseases(page: {index: 0, size: 3}) {
+          rows { disease { name id } score }
         }
       }
     }"
   }' | jq '.data.target'
 ```
 
-### Disease-Centric Queries
+### Open Targets: Disease-Centric Queries — curl only
 
+**RETRIEVE**: Get targets associated with disease
 ```bash
-# Get targets associated with disease (breast cancer = EFO_0000305)
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ disease(efoId: \"EFO_0000305\") { name associatedTargets(page: {size: 5}) { rows { target { approvedSymbol } score } } } }"}' \
+  -d '{"query": "{ disease(efoId: \"EFO_0000305\") { name associatedTargets(page: {index: 0, size: 5}) { rows { target { approvedSymbol } score } } } }"}' \
   | jq '.data.disease.associatedTargets.rows[] | {target: .target.approvedSymbol, score}'
-
-# Search for disease by name
-curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ search(queryString: \"breast cancer\", entityNames: [\"disease\"]) { hits { id name } } }"}' \
-  | jq '.data.search.hits[:3]'
-```
-
-### Evidence Breakdown
-
-```bash
-# Get association with evidence type scores
-curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ disease(efoId: \"MONDO_0018875\") { name associatedTargets(page: {size: 3}) { rows { target { approvedSymbol } score datatypeScores { id score } } } } }"}' \
-  | jq '.data.disease.associatedTargets.rows[] | {target: .target.approvedSymbol, overall: .score, evidence: .datatypeScores}'
 ```
 
 ## ClinicalTrials.gov API v2
 
-### Search Clinical Trials
+### LOCATE: Search Clinical Trials
 
-```bash
-# Search by condition
-curl -s "https://clinicaltrials.gov/api/v2/studies?query.cond=breast+cancer&pageSize=3&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, title: .protocolSection.identificationModule.briefTitle, status: .protocolSection.statusModule.overallStatus}'
+**By condition**:
 
-# Search by intervention (drug)
-curl -s "https://clinicaltrials.gov/api/v2/studies?query.intr=venetoclax&pageSize=3&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, phase: .protocolSection.designModule.phases, status: .protocolSection.statusModule.overallStatus}'
-
-# Filter by status
-curl -s "https://clinicaltrials.gov/api/v2/studies?filter.overallStatus=RECRUITING&query.cond=leukemia&pageSize=3&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, title: .protocolSection.identificationModule.briefTitle}'
-
-# Filter by phase
-curl -s "https://clinicaltrials.gov/api/v2/studies?filter.advanced=AREA[Phase]PHASE3&query.cond=cancer&pageSize=3&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, phases: .protocolSection.designModule.phases}'
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_search_trials` with: {"query": "breast cancer"}
+→ Returns: NCT IDs, titles, phases, statuses
 ```
 
-### Get Trial Details
-
+FALLBACK (curl):
 ```bash
-# Get full trial by NCT ID
+curl -s "https://clinicaltrials.gov/api/v2/studies?query.cond=breast+cancer&pageSize=3&format=json" \
+  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, title: .protocolSection.identificationModule.briefTitle, status: .protocolSection.statusModule.overallStatus}'
+```
+
+**By intervention (drug)**:
+
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_search_trials` with: {"query": "venetoclax"}
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://clinicaltrials.gov/api/v2/studies?query.intr=venetoclax&pageSize=3&format=json" \
+  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, phase: .protocolSection.designModule.phases, status: .protocolSection.statusModule.overallStatus}'
+```
+
+**By status** (curl only — more parameter control):
+```bash
+curl -s "https://clinicaltrials.gov/api/v2/studies?filter.overallStatus=RECRUITING&query.cond=leukemia&pageSize=3&format=json" \
+  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, title: .protocolSection.identificationModule.briefTitle}'
+```
+
+**By study type** (use `query.term` with AREA syntax — `filter.studyType` is NOT valid in v2):
+```bash
+curl -s "https://clinicaltrials.gov/api/v2/studies?query.term=AREA[StudyType]INTERVENTIONAL&query.cond=cancer&pageSize=3&format=json" \
+  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId}'
+```
+
+### RETRIEVE: Get Trial Details
+
+**By NCT ID**:
+
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_get_trial` with: {"nct_id": "NCT00461032"}
+→ Returns: title, status, phase, conditions, interventions
+```
+
+FALLBACK (curl):
+```bash
 curl -s "https://clinicaltrials.gov/api/v2/studies/NCT00461032?format=json" \
   | jq '{
     nct: .protocolSection.identificationModule.nctId,
@@ -135,98 +174,111 @@ curl -s "https://clinicaltrials.gov/api/v2/studies/NCT00461032?format=json" \
     conditions: .protocolSection.conditionsModule.conditions,
     interventions: [.protocolSection.armsInterventionsModule.interventions[]?.name]
   }'
-
-# Get eligibility criteria
-curl -s "https://clinicaltrials.gov/api/v2/studies/NCT00461032?format=json" \
-  | jq '.protocolSection.eligibilityModule | {criteria: .eligibilityCriteria, minAge, maxAge, sex}'
 ```
 
-### Pagination
+### RETRIEVE: Get Trial Locations
 
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_get_trial_locations` with: {"nct_id": "NCT00461032"}
+→ Returns: trial site locations
+```
+
+FALLBACK (curl):
 ```bash
-# Get page token for next page
-RESPONSE=$(curl -s "https://clinicaltrials.gov/api/v2/studies?query.cond=cancer&pageSize=10&format=json")
-NEXT_TOKEN=$(echo $RESPONSE | jq -r '.nextPageToken')
-
-# Get next page
-curl -s "https://clinicaltrials.gov/api/v2/studies?query.cond=cancer&pageSize=10&pageToken=$NEXT_TOKEN&format=json"
+curl -s "https://clinicaltrials.gov/api/v2/studies/NCT00461032?format=json" \
+  | jq '.protocolSection.contactsLocationsModule.locations[:5]'
 ```
+
+## Quick Reference
+
+| Task | Pattern | MCP Tool (primary) | Curl Endpoint (fallback) |
+|------|---------|-------------------|--------------------------|
+| Search diseases | LOCATE | `opentargets_search_targets` | Open Targets GraphQL `search` |
+| Target-disease associations | RETRIEVE | `opentargets_get_associations` | Open Targets GraphQL `associatedDiseases` |
+| Target tractability | RETRIEVE | (curl only) | Open Targets GraphQL `tractability` |
+| Known drugs for target | LOCATE | `opentargets_get_target` | Open Targets GraphQL `knownDrugs` |
+| Disease → targets | RETRIEVE | (curl only) | Open Targets GraphQL `associatedTargets` |
+| Search trials | LOCATE | `clinicaltrials_search_trials` | ClinicalTrials.gov `/studies?query.*` |
+| Get trial details | RETRIEVE | `clinicaltrials_get_trial` | ClinicalTrials.gov `/studies/{NCT}` |
+
+## ClinicalTrials.gov v2 Valid Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `query.cond` | Condition/disease | `breast+cancer` |
+| `query.intr` | Intervention/drug | `venetoclax` |
+| `query.term` | General search (supports AREA syntax) | `AREA[StudyType]INTERVENTIONAL` |
+| `filter.overallStatus` | Status filter | `RECRUITING`, `COMPLETED` |
+| `pageSize` | Results per page | `10` |
+| `pageToken` | Pagination token | From previous response |
+| `format` | Response format | `json` |
+
+**Invalid**: `filter.studyType` does NOT exist in v2 API.
+
+## ID Format Reference
+
+| Database | API Argument | Graph CURIE | Example |
+|----------|-------------|-------------|---------|
+| Open Targets (target) | `ENSG00000141510` | `ENSG00000141510` | Ensembl gene ID |
+| Open Targets (disease) | `EFO_0000305` | `EFO:0000305` | EFO with underscore for API |
+| ClinicalTrials.gov | `NCT03312634` | `NCT03312634` | NCT ID (bare) |
 
 ## Common Workflows
 
 ### Drug Target Validation Pipeline
 
-```bash
-# 1. Get target-disease association score
-curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { approvedSymbol associatedDiseases(page: {size: 1}) { rows { disease { id name } score } } } }"}' \
-  | jq '.data.target'
+```
+# Step 1: RETRIEVE — Get target-disease association score (MCP)
+Call `opentargets_get_associations` with: {"ensembl_id": "ENSG00000171791"}
 
-# 2. Check tractability
+# Step 2: RETRIEVE — Check tractability (curl — no MCP tool for this)
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
   -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { tractability { label modality value } } }"}' \
   | jq '.data.target.tractability'
 
-# 3. Find clinical trials for the target
-curl -s "https://clinicaltrials.gov/api/v2/studies?query.intr=BCL2&filter.overallStatus=RECRUITING&pageSize=5&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, title: .protocolSection.identificationModule.briefTitle}'
+# Step 3: LOCATE — Find clinical trials (MCP)
+Call `clinicaltrials_search_trials` with: {"query": "BCL2 RECRUITING"}
 ```
 
-### Disease → Targets → Drugs → Trials
+### Disease → Targets → Drugs → Trials (Full Chain)
 
-```bash
-# 1. Find top targets for disease
-curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ disease(efoId: \"EFO_0000574\") { name associatedTargets(page: {size: 3}) { rows { target { approvedSymbol } score } } } }"}' \
-  | jq '.data.disease'
-
-# 2. Get drugs for top target
-curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { knownDrugs(page: {size: 5}) { rows { drug { name id } phase } } } }"}' \
-  | jq '.data.target.knownDrugs.rows'
-
-# 3. Find trials for drug
-curl -s "https://clinicaltrials.gov/api/v2/studies?query.intr=venetoclax&filter.overallStatus=RECRUITING&pageSize=3&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, condition: .protocolSection.conditionsModule.conditions[0]}'
 ```
+# Step 1: LOCATE — Find top targets for disease (curl — disease-centric query)
+curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ disease(efoId: \"EFO_0000574\") { name associatedTargets(page: {index: 0, size: 3}) { rows { target { approvedSymbol ensemblId: id } score } } } }"}'
+
+# Step 2: LOCATE — Get drugs for top target (MCP)
+Call `opentargets_get_target` with: {"ensembl_id": "ENSG00000171791"}
+
+# Step 3: LOCATE — Find trials for drug (MCP)
+Call `clinicaltrials_search_trials` with: {"query": "venetoclax leukemia RECRUITING"}
+```
+
+## Fallback Patterns
+
+| Primary Search | Fallback | When |
+|---------------|----------|------|
+| Drug + disease trial search | Disease-only search | Zero results for drug+disease combination |
+| Specific drug name search | Broader mechanism class search | Drug name not in ClinicalTrials.gov |
 
 ## Rate Limits
 
 | API | Limit | Notes |
 |-----|-------|-------|
-| Open Targets | 100 req/s | No auth required |
-| ClinicalTrials.gov | Varies | May block automated clients |
+| Open Targets | ~5 req/s (practical) | No auth required; 0.2s delay in production |
+| ClinicalTrials.gov | Varies | May block automated clients; curl is reliable |
 
-## Notes
+## Pitfalls
 
+- **Open Targets requires Ensembl Gene IDs** (ENSG*) for target queries; use EFO IDs for disease queries.
+- **Always include `index: 0`** in Open Targets pagination: `page: {index: 0, size: N}`.
 - **ClinicalTrials.gov** uses Cloudflare protection that may block Python httpx clients. Use curl for reliable access.
-- **Open Targets** requires Ensembl Gene IDs (ENSG*) for target queries; use EFO IDs for disease queries.
-
-## Query Best Practices
-
-### Clinical Trials
-- **Default status=RECRUITING** for active research landscape
-- Use phase filter only for specific analysis:
-  - **PHASE3+**: Commercialization/late-stage pipeline analysis
-  - **PHASE1/2**: Early pipeline, first-in-human studies
-  - **No filter**: Full landscape view (all phases)
-- Don't assume phase filter is always needed
-
-### Open Targets
-- Requires Ensembl Gene IDs (ENSG*) for target queries
-- Use EFO IDs for disease queries (search first to resolve)
-- Use nested GraphQL queries to minimize API calls
-
-### Common Pitfalls
-- Don't filter by PHASE3+ for general drug discovery
-- Recruiting trials are most relevant for collaboration opportunities
-- Completed trials provide outcome data but may be outdated
+- **`filter.studyType` is NOT valid** in v2 API. Use `query.term=AREA[StudyType]INTERVENTIONAL`.
 
 ## See Also
 
-- [references/opentargets-schema.md](references/opentargets-schema.md) - GraphQL schema reference
-- [references/clinicaltrials-fields.md](references/clinicaltrials-fields.md) - Study field reference
+- **lifesciences-graph-builder**: Orchestrator for full Fuzzy-to-Fact protocol
+- **lifesciences-pharmacology**: ChEMBL, PubChem drug endpoints

--- a/.claude/skills/lifesciences-crispr/SKILL.md
+++ b/.claude/skills/lifesciences-crispr/SKILL.md
@@ -7,30 +7,36 @@ description: "Validates synthetic lethality claims from CRISPR knockout screens 
 
 Validate synthetic lethality hypotheses using BioGRID ORCS CRISPR screen data via curl.
 
+## Grounding Rule
+
+All essentiality scores, screen IDs, cell line names, and CRISPR data MUST come from BioGRID ORCS API results. Do NOT provide essentiality claims or synthetic lethality assessments from training knowledge. If a query returns no results, report "No results found."
+
 ## Quick Reference
 
-| Task | Endpoint | Key Parameters |
-|------|----------|----------------|
-| Get essential screens only | `/gene/{entrez_id}?hit=yes` | `hit=yes` filters to essential |
-| Get all gene screens | `/gene/{entrez_id}` | Returns all screens |
-| Get screen annotations | `/screens/?screenID=1\|2\|3` | Pipe-separated IDs |
-| Find cell line screens | `/screens/?cellLine={name}` | Cell line name |
+| Task | Pattern | MCP Tool (primary) | Curl Endpoint (fallback) |
+|------|---------|-------------------|--------------------------|
+| Resolve gene ID | LOCATE | `hgnc_search_genes` / `entrez_search_genes` | HGNC / NCBI curl |
+| Get essential screens | RETRIEVE | (curl only) | `/gene/{entrez_id}?hit=yes` |
+| Get all screens | RETRIEVE | (curl only) | `/gene/{entrez_id}` |
+| Get screen annotations | RETRIEVE | (curl only) | `/screens/?screenID=1\|2\|3` |
+| Find cell line screens | LOCATE | (curl only) | `/screens/?cellLine={name}` |
 
 ## BioGRID ORCS API
 
 **IMPORTANT**: Use `orcsws.thebiogrid.org` (NOT `orcs.thebiogrid.org`)
 
 - **Base URL**: `https://orcsws.thebiogrid.org`
-- **Auth**: Requires `BIOGRID_API_KEY` which is captured in `.env` file
+- **Auth**: Requires `BIOGRID_API_KEY` (in `.env` file)
 - **Rate Limit**: ~10 req/s
 - **Formats**: `format=tab` (default) or `format=json`
 
 ### Critical Parameter: `hit=yes`
 
-**Always use `hit=yes` when querying gene essentiality.** This filters results to only screens where the gene scored as a hit (essential), dramatically reducing data volume:
+**Always use `hit=yes` when querying gene essentiality.** This filters to screens where the gene scored as a hit (essential):
 
 - Without filter: ~1,400 records (all screens)
 - With `hit=yes`: ~300-400 records (essential screens only)
+- Reduces data volume by ~75%
 
 ### Data Format (JSON)
 
@@ -46,37 +52,37 @@ Validate synthetic lethality hypotheses using BioGRID ORCS CRISPR screen data vi
 }
 ```
 
-### Screen Annotation Fields
-
-Query `/screens/?screenID={ids}` to get cell line and publication data:
-- `SCREEN_ID`: Unique screen identifier
-- `SOURCE_ID`: PubMed ID
-- `AUTHOR`: First author and year
-- `CELL_LINE`: Cell line name
-- `PHENOTYPE`: Screen phenotype (e.g., "cell proliferation")
-
 ## 5-Phase Synthetic Lethality Validation Workflow
 
-### Phase 1: Resolve Gene Identifiers
+### Phase 1: LOCATE — Resolve Gene Identifiers
 
-Use Life Sciences MCPs to get Entrez IDs:
+Use MCP tools to get Entrez IDs (required for ORCS API):
 
-```bash
-# Using HGNC MCP: search_genes → get_gene
-# Extract "entrez" from cross_references object
-# Example: DHODH → {"cross_references": {"entrez": "1723"}}
-
-# Using Entrez MCP: search_genes
-# Top result format: "NCBIGene:1723"
-# Extract numeric ID: 1723
+PRIMARY (MCP tool):
+```
+Call `hgnc_search_genes` with: {"query": "DHODH"}
+→ Returns HGNC record with entrez_id cross-reference
+→ Extract entrez_id: "1723"
 ```
 
-### Phase 2: Query ORCS for Essential Screens Only
+ALTERNATIVE (MCP tool):
+```
+Call `entrez_search_genes` with: {"query": "DHODH", "organism": "human"}
+→ Returns Entrez gene ID directly: "1723"
+```
 
-**CRITICAL: Always use `hit=yes` to filter to essential screens:**
+FALLBACK (curl):
+```bash
+curl -s "https://rest.genenames.org/search/symbol/DHODH" \
+  -H "Accept: application/json" | jq '.response.docs[0] | {hgnc_id, symbol, entrez_id}'
+```
+
+### Phase 2: RETRIEVE — Query ORCS for Essential Screens Only
+
+**CRITICAL: Always use `hit=yes`**:
 
 ```bash
-# Get ONLY screens where gene is essential (hit=yes)
+# RETRIEVE: Get ONLY screens where gene is essential
 curl -s "https://orcsws.thebiogrid.org/gene/7298?accesskey=${BIOGRID_API_KEY}&hit=yes&format=json" > gene_essential.json
 
 # Count essential screens
@@ -84,21 +90,16 @@ cat gene_essential.json | jq '. | length'
 # Output: 352 (vs 1,446 without hit=yes filter)
 ```
 
-**Why this matters:**
-- Without `hit=yes`: Returns ALL screens (~1,400 records)
-- With `hit=yes`: Returns only screens where gene is essential (~300-400 records)
-- Reduces data volume by 75% and focuses on biologically meaningful results
+### Phase 3: RETRIEVE — Get Screen Annotations (Cell Lines & PubMed)
 
-### Phase 3: Get Screen Annotations (Cell Lines & PubMed)
-
-**Two-step workflow**: Query gene for screen IDs, then query screens for annotations.
+Two-step pattern: query gene for screen IDs, then query screens for annotations.
 
 ```bash
 # Step 3a: Extract unique screen IDs from essential screens
 SCREEN_IDS=$(curl -s "https://orcsws.thebiogrid.org/gene/7298?accesskey=${BIOGRID_API_KEY}&hit=yes&format=json" | \
   jq -r '.[].SCREEN_ID' | sort -u | head -20 | tr '\n' '|' | sed 's/|$//')
 
-# Step 3b: Get screen annotations (cell line, PubMed, author)
+# Step 3b: RETRIEVE screen annotations (cell line, PubMed, author)
 curl -s "https://orcsws.thebiogrid.org/screens/?accesskey=${BIOGRID_API_KEY}&screenID=${SCREEN_IDS}&format=json" | \
   jq '.[] | {SCREEN_ID, SOURCE_ID, AUTHOR, CELL_LINE, PHENOTYPE}'
 ```
@@ -114,34 +115,21 @@ curl -s "https://orcsws.thebiogrid.org/screens/?accesskey=${BIOGRID_API_KEY}&scr
 }
 ```
 
-This gives you:
-- `SOURCE_ID`: PubMed ID for the screen publication
-- `AUTHOR`: First author and year
-- `CELL_LINE`: Cell line name for cross-referencing with DepMap/CCLE
-
-### Phase 4: Extract Dependency Scores
-
-With JSON format, extract scores using jq:
+### Phase 4: RETRIEVE — Extract Dependency Scores
 
 ```bash
-# Get essential screens with scores
+# RETRIEVE: Get essential screens with scores
 curl -s "https://orcsws.thebiogrid.org/gene/7298?accesskey=${BIOGRID_API_KEY}&hit=yes&format=json" | \
   jq '.[] | select(.SCREEN_ID == "16" or .SCREEN_ID == "17") | {SCREEN_ID, SCORE: .["SCORE.1"], symbol: .OFFICIAL_SYMBOL}'
 ```
 
-**Example output:**
-```json
-{"SCREEN_ID": "16", "SCORE": "100.84", "symbol": "TYMS"}
-{"SCREEN_ID": "17", "SCORE": "107.563", "symbol": "TYMS"}
-```
-
-**Interpretation:**
+**Score interpretation:**
 - **HIT = YES** = gene is essential in this screen
 - **Positive BAGEL score** = essential (Bayes Factor)
 - **Negative CERES score** = essential (depletion)
 - Different screens use different scoring methods (check screen metadata)
 
-### Phase 5: Compare Across Genetic Backgrounds
+### Phase 5: RETRIEVE — Compare Across Genetic Backgrounds
 
 Calculate essentiality rate across all screens:
 
@@ -171,126 +159,32 @@ curl -s "https://orcsws.thebiogrid.org/screens/?accesskey=${BIOGRID_API_KEY}&scr
 | **MAGeCK** | Model-based Analysis of Genome-wide CRISPR | Negative = depletion = essential |
 | **BAGEL** | Bayesian Analysis of Gene EssentiaLity | Bayes Factor, positive = essential |
 
+## ID Format Reference
+
+| Database | API Argument (bare) | Graph CURIE | Example |
+|----------|---------------------|-------------|---------|
+| NCBI/Entrez | `7298` | `NCBIGene:7298` | Bare numeric for ORCS API |
+| HGNC | `HGNC:11998` | `HGNC:11998` | Includes prefix |
+| BioGRID Screen | `16` | N/A | Numeric screen ID |
+
 ## Common Pitfalls
 
 1. **Wrong endpoint**: Use `orcsws.thebiogrid.org` (NOT `orcs.thebiogrid.org`)
-2. **Missing API key**: Check `.env` file first: `grep BIOGRID_API_KEY .env`
+2. **Missing API key**: Check first: `grep BIOGRID_API_KEY .env`
 3. **Missing hit filter**: Always use `hit=yes` to filter to essential screens only
 4. **Gene identifiers**: Always use Entrez IDs (not gene symbols) for `/gene/{id}` endpoint
 5. **Screen metadata**: Query `/screens/?screenID=...` to get cell line and PubMed data
 6. **Batch screen queries**: Use pipe-separated IDs: `/screens/?screenID=16|17|141`
 
-## Complete Example
+## Integration with Fuzzy-to-Fact Protocol
 
-See [references/biogrid-orcs-validation.md](references/biogrid-orcs-validation.md) for a complete worked example validating DHODH/VHL synthetic lethality from a Science Advances paper.
+In the context of the lifesciences-graph-builder workflow:
+1. **ANCHOR phase**: Use `hgnc_search_genes` MCP tool to LOCATE gene → get Entrez ID from cross-references
+2. **EXPAND phase**: Query ORCS with Entrez ID (this skill's Phase 2-5)
+3. **VALIDATE phase**: Verify screen IDs and cell line data
+4. **PERSIST phase**: Include essentiality edges in knowledge graph
 
-**Result**: 2/4 VHL-mutant lines show significant DHODH dependency (context-dependent penetrance).
+## See Also
 
-## Python Code Patterns
-
-For programmatic access, use these patterns from `kg_rememberall/notebooks/biogrid_orcs_api.ipynb`:
-
-### Query Gene Essentiality
-
-```python
-import requests
-
-BIOGRID_API_KEY = os.getenv("BIOGRID_API_KEY")
-BASE_URL = "https://orcsws.thebiogrid.org"
-
-def get_essential_screens(entrez_id: int) -> list[dict]:
-    """Get screens where gene is essential (hit=yes)."""
-    response = requests.get(
-        f"{BASE_URL}/gene/{entrez_id}",
-        params={
-            "accesskey": BIOGRID_API_KEY,
-            "hit": "yes",
-            "format": "json"
-        }
-    )
-    return response.json()
-
-# Example: Get TYMS (Entrez 7298) essential screens
-essential_screens = get_essential_screens(7298)
-print(f"TYMS essential in {len(essential_screens)} screens")
-# Output: TYMS essential in 352 screens
-```
-
-### Get Screen Annotations with PubMed
-
-```python
-def get_screen_annotations(screen_ids: list[str]) -> list[dict]:
-    """Get cell line and publication data for screens."""
-    response = requests.get(
-        f"{BASE_URL}/screens/",
-        params={
-            "accesskey": BIOGRID_API_KEY,
-            "screenID": "|".join(screen_ids),
-            "format": "json"
-        }
-    )
-    return response.json()
-
-# Extract unique screen IDs from essential screens
-screen_ids = list(set(s["SCREEN_ID"] for s in essential_screens))
-
-# Get annotations (batched)
-annotations = get_screen_annotations(screen_ids[:20])  # First 20
-
-for a in annotations[:5]:
-    print(f"Screen {a['SCREEN_ID']}: {a['CELL_LINE']} - PMID:{a['SOURCE_ID']} ({a['AUTHOR']})")
-```
-
-### Calculate Essentiality Rate
-
-```python
-def calculate_essentiality_rate(entrez_id: int) -> tuple[int, int, float]:
-    """Calculate what % of screens show gene as essential."""
-    # Get all screens
-    all_screens = requests.get(
-        f"{BASE_URL}/gene/{entrez_id}",
-        params={"accesskey": BIOGRID_API_KEY, "format": "json"}
-    ).json()
-
-    # Get essential screens only
-    essential = requests.get(
-        f"{BASE_URL}/gene/{entrez_id}",
-        params={"accesskey": BIOGRID_API_KEY, "hit": "yes", "format": "json"}
-    ).json()
-
-    total = len(all_screens)
-    essential_count = len(essential)
-    rate = essential_count / total * 100 if total > 0 else 0
-
-    return essential_count, total, rate
-
-# Example
-essential, total, rate = calculate_essentiality_rate(7298)
-print(f"TYMS: {essential}/{total} screens ({rate:.1f}%) show essentiality")
-# Output: TYMS: 352/1446 screens (24.3%) show essentiality
-```
-
-## Integration with Life Sciences MCPs
-
-**Workflow:**
-1. Use HGNC or Entrez MCP to resolve gene symbols to Entrez IDs
-2. Query ORCS for essentiality data using Entrez IDs
-3. Analyze dependency scores across cell lines
-4. Validate synthetic lethality hypotheses
-
-**Example:**
-```python
-# Phase 1: Use MCP to get Entrez ID
-hgnc_result = await client.call_tool("hgnc_search_genes", {"query": "DHODH"})
-gene = await client.call_tool("hgnc_get_gene", {"hgnc_id": hgnc_result["items"][0]["id"]})
-entrez_id = gene["cross_references"]["entrez"]  # "1723"
-
-# Phase 2-5: Use curl with ORCS (see workflow above)
-```
-
-## References
-
-- **BioGRID ORCS**: https://orcs.thebiogrid.org/
-- **API Key**: https://webservice.thebiogrid.org/
-- **Meyers RM et al. 2017**: CERES methodology (PMID: 29083409)
-- **Complete Example**: [references/biogrid-orcs-validation.md](references/biogrid-orcs-validation.md)
+- **lifesciences-graph-builder**: Orchestrator for full Fuzzy-to-Fact protocol
+- **lifesciences-genomics**: Gene resolution endpoints (HGNC, Ensembl, NCBI)

--- a/.claude/skills/lifesciences-genomics/SKILL.md
+++ b/.claude/skills/lifesciences-genomics/SKILL.md
@@ -1,111 +1,196 @@
 ---
 name: lifesciences-genomics
-description: "Queries genomic databases (Ensembl, NCBI, HGNC) via curl for gene lookup, variant annotation, orthology, and cross-database ID resolution. This skill should be used when the user asks to \"annotate variants\", \"find orthologs\", \"map gene IDs\", \"analyze linkage disequilibrium\", or mentions gene symbols, ENSG IDs, HGNC identifiers, VEP annotation, LD analysis, HGVS notation, or DNA sequences."
+description: "Queries genomic databases (Ensembl, NCBI, HGNC) via MCP tools for gene lookup, variant annotation, orthology, and cross-database ID resolution. Falls back to curl when MCP is unavailable. This skill should be used when the user asks to \"annotate variants\", \"find orthologs\", \"map gene IDs\", \"analyze linkage disequilibrium\", or mentions gene symbols, ENSG IDs, HGNC identifiers, VEP annotation, LD analysis, HGVS notation, or DNA sequences."
 ---
 
 # Genomics API Skills
 
-Query genomic databases directly via curl. These endpoints complement the Life Sciences MCPs.
+Query genomic databases via MCP tools (primary) or curl (fallback).
 
-## Quick Reference
+## Grounding Rule
 
-| Task | API | Endpoint |
-|------|-----|----------|
-| Resolve gene symbol | HGNC | `/search/{symbol}` |
-| Get gene metadata | Ensembl | `/lookup/id/{ENSG}` |
-| Annotate variant | Ensembl VEP | `/vep/:species/hgvs` |
-| Find orthologs | Ensembl | `/homology/id/:species/:id` |
-| Cross-reference IDs | Ensembl | `/xrefs/id/{ENSG}` |
-| Search NCBI Gene | E-utilities | `/esearch.fcgi?db=gene` |
-| Link gene→PubMed | E-utilities | `/elink.fcgi?dbfrom=gene&db=pubmed` |
+All gene names, IDs, and annotations MUST come from API results. Do NOT provide gene information from training knowledge. If a query returns no results, report "No results found."
 
-## Curl Examples
+## LOCATE → RETRIEVE Patterns
 
-### HGNC: Resolve Gene Symbol
+### Gene Resolution (HGNC — Start Here)
 
+**LOCATE**: Search for gene by symbol or name
+
+PRIMARY (MCP tool):
+```
+Call `hgnc_search_genes` with: {"query": "TP53"}
+→ Returns candidates with HGNC IDs, symbols, names
+```
+
+FALLBACK (curl):
 ```bash
-# Search for gene by symbol
 curl -s "https://rest.genenames.org/search/symbol/TP53" \
   -H "Accept: application/json" | jq '.response.docs[0] | {hgnc_id, symbol, name}'
+```
 
-# Fetch by HGNC ID
+**RETRIEVE**: Fetch full record by HGNC ID
+
+PRIMARY (MCP tool):
+```
+Call `hgnc_get_gene` with: {"hgnc_id": "HGNC:11998"}
+→ Returns: symbol, name, cross-references (UniProt, Ensembl, Entrez)
+```
+
+FALLBACK (curl):
+```bash
 curl -s "https://rest.genenames.org/fetch/hgnc_id/11998" \
   -H "Accept: application/json" | jq '.response.docs[0]'
 ```
 
-### Ensembl: Gene Lookup & Metadata
+### Gene Metadata (Ensembl)
 
-```bash
-# Lookup gene by Ensembl ID
-curl -s "https://rest.ensembl.org/lookup/id/ENSG00000141510?expand=1&content-type=application/json" \
-  | jq '{id, display_name, biotype, description, seq_region_name, start, end}'
+**LOCATE**: Resolve symbol to Ensembl ID
 
-# Resolve symbol to Ensembl ID
-curl -s "https://rest.ensembl.org/lookup/symbol/homo_sapiens/TP53?content-type=application/json" \
-  | jq '{id, display_name}'
-
-# Get sequence
-curl -s "https://rest.ensembl.org/sequence/id/ENSG00000141510?type=genomic&content-type=application/json" \
-  | jq '.seq[:100]'
+PRIMARY (MCP tool):
+```
+Call `ensembl_search_genes` with: {"query": "TP53", "species": "homo_sapiens"}
+→ Returns Ensembl gene ID (ENSG...)
 ```
 
-### Ensembl VEP: Variant Annotation
-
+FALLBACK (curl):
 ```bash
-# Annotate variant by rsID
+curl -s "https://rest.ensembl.org/lookup/symbol/homo_sapiens/TP53?content-type=application/json" \
+  | jq '{id, display_name}'
+```
+
+**RETRIEVE**: Get full gene metadata by Ensembl ID
+
+PRIMARY (MCP tool):
+```
+Call `ensembl_get_gene` with: {"ensembl_id": "ENSG00000141510"}
+→ Returns: biotype, description, location, transcripts
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://rest.ensembl.org/lookup/id/ENSG00000141510?expand=1&content-type=application/json" \
+  | jq '{id, display_name, biotype, description, seq_region_name, start, end}'
+```
+
+### Variant Annotation (Ensembl VEP)
+
+No MCP tool — use curl directly:
+
+**LOCATE**: Annotate variant by rsID
+```bash
 curl -s "https://rest.ensembl.org/vep/human/id/rs56116432?content-type=application/json" \
   | jq '.[0] | {most_severe_consequence, transcript_consequences: .transcript_consequences[:2]}'
+```
 
-# Annotate by HGVS notation (POST for batch)
+**RETRIEVE**: Annotate by HGVS notation (batch via POST)
+```bash
 curl -s -X POST "https://rest.ensembl.org/vep/human/hgvs" \
   -H "Content-Type: application/json" \
   -d '{"hgvs_notations": ["ENST00000366667:c.803C>T"]}' \
   | jq '.[0].transcript_consequences[0] | {consequence_terms, sift_prediction, polyphen_prediction}'
 ```
 
-### Ensembl: Orthology
+### Orthology (Ensembl)
 
+No MCP tool — use curl directly:
+
+**LOCATE + RETRIEVE** (single call returns both):
 ```bash
-# Find orthologs for TP53
 curl -s "https://rest.ensembl.org/homology/id/human/ENSG00000141510?type=orthologues&content-type=application/json" \
   | jq '.data[0].homologies[:5][] | {species: .target.species, gene_id: .target.id, perc_id: .target.perc_id}'
 ```
 
-### Ensembl: Cross-References
+### Cross-Database ID Resolution (Ensembl xrefs)
 
+No MCP tool — use curl directly:
+
+**RETRIEVE**: Get all cross-references for a gene (useful for verification)
 ```bash
-# Get all cross-references for gene
 curl -s "https://rest.ensembl.org/xrefs/id/ENSG00000141510?content-type=application/json" \
   | jq '.[] | select(.dbname | test("HGNC|UniProt|OMIM|RefSeq")) | {db: .dbname, id: .primary_id}'
 ```
 
-### Ensembl: Linkage Disequilibrium
+### Linkage Disequilibrium (Ensembl)
 
+No MCP tool — use curl directly:
+
+**RETRIEVE**: LD between two variants
 ```bash
-# LD between two variants
 curl -s "https://rest.ensembl.org/ld/human/pairwise/rs56116432/rs1042522?population_name=1000GENOMES:phase_3:EUR&content-type=application/json" \
   | jq '.[0] | {r2, d_prime}'
+```
 
-# LD in genomic region
+**RETRIEVE**: LD in genomic region
+```bash
 curl -s "https://rest.ensembl.org/ld/human/region/17:7668421..7687490/1000GENOMES:phase_3:EUR?content-type=application/json" \
   | jq '.[:3]'
 ```
 
 ### NCBI E-utilities: Gene Search & Links
 
+**LOCATE**: Search for gene
+
+PRIMARY (MCP tool):
+```
+Call `entrez_search_genes` with: {"query": "TP53", "organism": "human"}
+→ Returns Entrez gene IDs
+```
+
+FALLBACK (curl):
 ```bash
-# Search for gene
 curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=gene&term=TP53[sym]+AND+human[orgn]&retmode=json" \
   | jq '.esearchresult | {count, idlist}'
+```
 
-# Get gene summary
+**RETRIEVE**: Get gene summary by Entrez ID
+
+PRIMARY (MCP tool):
+```
+Call `entrez_get_gene` with: {"gene_id": "7157"}
+→ Returns gene name, description, chromosome location
+```
+
+FALLBACK (curl):
+```bash
 curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=gene&id=7157&retmode=json" \
   | jq '.result["7157"] | {name: .name, description: .description, chromosome: .chromosome}'
+```
 
-# Link gene to PubMed articles
+**RETRIEVE**: Link gene to PubMed articles
+
+PRIMARY (MCP tool):
+```
+Call `entrez_get_pubmed_links` with: {"gene_id": "7157"}
+→ Returns linked PubMed article IDs
+```
+
+FALLBACK (curl):
+```bash
 curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi?dbfrom=gene&db=pubmed&id=7157&retmode=json" \
   | jq '.linksets[0].linksetdbs[] | select(.dbto=="pubmed") | {db: .dbto, count: (.links | length)}'
 ```
+
+## Quick Reference
+
+| Task | Pattern | MCP Tool (primary) | Curl Endpoint (fallback) |
+|------|---------|-------------------|--------------------------|
+| Resolve gene symbol | LOCATE | `hgnc_search_genes` | HGNC `/search/{symbol}` |
+| Get gene metadata | RETRIEVE | `hgnc_get_gene` | HGNC `/fetch/hgnc_id/{id}` |
+| Get Ensembl gene | RETRIEVE | `ensembl_get_gene` | Ensembl `/lookup/id/{ENSG}` |
+| Annotate variant | LOCATE | (curl only) | Ensembl VEP `/vep/:species/hgvs` |
+| Find orthologs | RETRIEVE | (curl only) | Ensembl `/homology/id/:species/:id` |
+| Cross-reference IDs | RETRIEVE | (curl only) | Ensembl `/xrefs/id/{ENSG}` |
+| Search NCBI Gene | LOCATE | `entrez_search_genes` | E-utilities `/esearch.fcgi?db=gene` |
+| Link gene→PubMed | RETRIEVE | `entrez_get_pubmed_links` | E-utilities `/elink.fcgi?dbfrom=gene&db=pubmed` |
+
+## ID Format Reference
+
+| Database | API Argument (bare) | Graph CURIE | Example |
+|----------|---------------------|-------------|---------|
+| HGNC | `HGNC:11998` | `HGNC:11998` | (Same — HGNC includes prefix) |
+| Ensembl | `ENSG00000141510` | `ENSG00000141510` | (No CURIE prefix needed) |
+| NCBI/Entrez | `7157` | `NCBIGene:7157` | Bare numeric for API |
 
 ## Rate Limits
 
@@ -125,9 +210,9 @@ curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi?dbfrom=gene&db
 ### Efficient Querying
 - Use `page_size=10` for exploration
 - Use cross-reference endpoints to resolve IDs rather than multiple searches
-- Prefer Ensembl IDs (ENSG*) for programmatic access
+- Prefer Ensembl IDs (ENSG*) for programmatic access — most APIs accept them
 
 ## See Also
 
-- [references/ensembl-endpoints.md](references/ensembl-endpoints.md) - Full endpoint reference
-- [references/ncbi-eutils.md](references/ncbi-eutils.md) - E-utilities pipeline patterns
+- **lifesciences-graph-builder**: Orchestrator for full Fuzzy-to-Fact protocol
+- **lifesciences-proteomics**: UniProt, STRING, BioGRID protein endpoints

--- a/.claude/skills/lifesciences-graph-builder/SKILL.md
+++ b/.claude/skills/lifesciences-graph-builder/SKILL.md
@@ -1,209 +1,509 @@
 ---
 name: lifesciences-graph-builder
-description: "Orchestrates life sciences APIs to build knowledge graphs using the Fuzzy-to-Fact protocol, combining MCPs for nodes and curl for edges, then persisting to Graphiti. This skill should be used when the user asks to \"build knowledge graphs\", \"find biological connections\", \"explore drug repurposing\", \"validate drug targets\", or mentions traversing gene→protein→pathway→drug→disease paths, multi-API orchestration, or graph persistence workflows."
+description: "Orchestrates life sciences APIs to build knowledge graphs using the Fuzzy-to-Fact protocol, combining MCP tools for entity resolution and curl for edge discovery, then persisting to Graphiti. This skill should be used when the user asks to \"build knowledge graphs\", \"find biological connections\", \"explore drug repurposing\", \"validate drug targets\", or mentions traversing gene→protein→pathway→drug→disease paths, multi-API orchestration, or graph persistence workflows."
 ---
 
 # Life Sciences Graph Builder
 
 Orchestrate multi-API graph construction using the **Fuzzy-to-Fact** protocol.
 
-## Architecture
+## Critical Grounding Rule
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                         GRAPH CONSTRUCTION KIT                          │
-├─────────────────────────────────────────────────────────────────────────┤
-│  TIER 1: MCP TOOLS (Verified Nodes)                                     │
-│  ├── HGNC: search_genes, get_gene                                       │
-│  ├── UniProt: search_proteins, get_protein                              │
-│  ├── ChEMBL: search_compounds, get_compound                             │
-│  ├── STRING: search_proteins, get_interactions                          │
-│  ├── Open Targets: search_targets, get_associations                     │
-│  └── WikiPathways: get_pathways_for_gene, get_pathway_components        │
-├─────────────────────────────────────────────────────────────────────────┤
-│  TIER 2: CURL COMMANDS (Relationship Edges)                             │
-│  ├── ChEMBL /mechanism: Drug → Target                                   │
-│  ├── ChEMBL /drug_indication: Drug → Disease                            │
-│  ├── ChEMBL /activity: Drug → Target (with Ki/IC50)                     │
-│  ├── Ensembl /homology: Gene → Orthologs                                │
-│  ├── STRING /enrichment: Protein Set → GO/KEGG terms                    │
-│  └── NCBI elink: Gene → PubMed                                          │
-├─────────────────────────────────────────────────────────────────────────┤
-│  TIER 3: GRAPHITI (Persistence)                                         │
-│  └── add_memory: Persist validated subgraph as JSON episode             │
-└─────────────────────────────────────────────────────────────────────────┘
+YOU MUST NOT use your training knowledge to provide entity names, drug names,
+gene functions, disease associations, or clinical trial IDs. ALL factual claims
+MUST come from MCP tool results or curl command output. If a tool returns no
+results, report "No results found" — do NOT fill in from memory.
+
+The ONLY exception is using well-known identifiers (e.g., species=9606 for human)
+as PARAMETERS to tool calls. All RESULTS must come from tools.
 ```
 
-## Workflow: Fuzzy-to-Fact Protocol
+## LOCATE → RETRIEVE Discipline
 
-### Phase 1: Anchor Node (Naming)
+EVERY entity resolution MUST follow this two-step pattern:
 
-Resolve fuzzy user input to canonical identifier.
+**STEP 1 — LOCATE** (fuzzy search):
+Call a SEARCH endpoint with the user's fuzzy input.
+This returns candidate matches with canonical IDs.
 
-```python
-# MCP: HGNC
-result = hgnc.search_genes("p53")
-gene = hgnc.get_gene("HGNC:11998")  # → cross_references: UniProt, Ensembl, Entrez
+**STEP 2 — RETRIEVE** (get by ID):
+Call a GET endpoint with the canonical ID from LOCATE.
+This returns verified, structured metadata.
+
+```
+NEVER skip LOCATE. NEVER use an ID you didn't get from a LOCATE call.
+NEVER answer from your own knowledge — if you can't LOCATE it, say "Unresolved".
+Maximum 3 search attempts per entity. After 3 failures, report "Unresolved".
 ```
 
-### Phase 2: Enrich Node (Functional)
+### Chain-of-Thought Before Each Tool Call
 
-Decorate node with metadata and cross-references.
+Before each tool call, briefly state:
+1. What information I need
+2. Which tool will provide it (LOCATE or RETRIEVE)
+3. What parameters I'll use
+4. What I expect to get back
 
-```python
-# MCP: UniProt
-protein = uniprot.get_protein("UniProtKB:P04637")
-# → function text reveals interactors: BAX, BCL2, FAS
+This prevents calling the wrong tool or guessing parameters.
+
+## Tool Access
+
+The `lifesciences-research` MCP server provides 34 tools across 12 databases. **Use MCP tools as the primary method.** Fall back to curl only when the MCP server is unavailable.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                          GRAPH CONSTRUCTION KIT                               │
+│         34 MCP tools via lifesciences-research MCP server (PRIMARY)           │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  TIER 1: GENE/PROTEIN FOUNDATION                                             │
+│  ├── HGNC: hgnc_search_genes (LOCATE), hgnc_get_gene (RETRIEVE)             │
+│  ├── UniProt: uniprot_search_proteins (LOCATE), uniprot_get_protein          │
+│  ├── STRING: string_search_proteins (LOCATE), string_get_interactions,       │
+│  │           string_get_network_image_url                                     │
+│  └── BioGRID: biogrid_search_genes (LOCATE), biogrid_get_interactions        │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  TIER 2: DRUG DISCOVERY                                                       │
+│  ├── ChEMBL: chembl_search_compounds (LOCATE), chembl_get_compound,          │
+│  │           chembl_get_compounds_batch                                       │
+│  ├── Open Targets: opentargets_search_targets (LOCATE),                      │
+│  │           opentargets_get_target, opentargets_get_associations             │
+│  ├── PubChem: pubchem_search_compounds (LOCATE), pubchem_get_compound        │
+│  └── IUPHAR: iuphar_search_ligands, iuphar_get_ligand,                      │
+│              iuphar_search_targets, iuphar_get_target                         │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  TIER 3: PATHWAYS & CLINICAL                                                  │
+│  ├── WikiPathways: wikipathways_search_pathways,                             │
+│  │           wikipathways_get_pathway, wikipathways_get_pathways_for_gene,    │
+│  │           wikipathways_get_pathway_components                              │
+│  └── ClinicalTrials: clinicaltrials_search_trials (LOCATE),                  │
+│              clinicaltrials_get_trial, clinicaltrials_get_trial_locations     │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  TIER 4: GENOMICS & IDENTIFIERS                                               │
+│  ├── Ensembl: ensembl_search_genes (LOCATE), ensembl_get_gene,               │
+│  │            ensembl_get_transcript                                          │
+│  └── Entrez: entrez_search_genes (LOCATE), entrez_get_gene,                  │
+│              entrez_get_pubmed_links                                          │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  DIRECT API (curl — for GraphQL & edge discovery when MCP unavailable)        │
+│  ├── Open Targets GraphQL: knownDrugs, associatedDiseases, tractability      │
+│  ├── ChEMBL /mechanism: Drug → Target edges                                  │
+│  └── STRING /enrichment: Protein Set → GO/KEGG terms                         │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  GRAPHITI (Persistence)                                                       │
+│  └── persist_to_graphiti: Save validated subgraph as JSON episode             │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Phase 3: Expand Edges (Interactions)
+## CURIE Format Conventions
 
-Build adjacency list from interaction databases.
+Two contexts require different ID formats:
 
-```python
-# MCP: STRING
-interactions = string.get_interactions("STRING:9606.ENSP00000269305")
-# → MDM2 (0.999), SIRT1 (0.999), ATM (0.995)
+### API Arguments (bare IDs)
+Use bare IDs matching what the MCP server or API accepts:
+- `"Q04771"` for UniProt
+- `"CHEMBL25"` for ChEMBL compounds
+- `"9606.ENSP00000269305"` for STRING proteins
+- `"ENSG00000141510"` for Ensembl genes
+- `"HGNC:11998"` for HGNC (includes prefix — this is how HGNC API works)
+
+### Graph Node IDs (full CURIEs for Graphiti)
+Use `PREFIX:LOCAL_ID` format for persistence:
+- `"HGNC:11998"` for genes
+- `"UniProtKB:P04637"` for proteins
+- `"CHEMBL:3137309"` for compounds
+- `"STRING:9606.ENSP00000269305"` for STRING proteins
+- `"NCT03312634"` for trials (no prefix needed — NCT is the standard)
+- `"EFO:0000574"` or `"MONDO:0018875"` for diseases
+- `"WP:WP1742"` for pathways
+
+## Fuzzy-to-Fact Execution Checklist
+
+- [ ] Phase 1 ANCHOR: LOCATE gene/drug/disease → RETRIEVE canonical CURIEs
+- [ ] Phase 2 ENRICH: RETRIEVE metadata for each CURIE (UniProt function, cross-refs)
+- [ ] Phase 3 EXPAND: LOCATE interaction partners → RETRIEVE pathway membership
+- [ ] Phase 4a TRAVERSE_DRUGS: LOCATE drugs targeting identified proteins → RETRIEVE mechanisms
+- [ ] Phase 4b TRAVERSE_TRIALS: LOCATE trials for identified drugs → RETRIEVE trial details
+- [ ] Phase 5 VALIDATE: RETRIEVE verification for every NCT ID, drug mechanism, gene-disease link
+- [ ] Phase 6 PERSIST: Format validated graph as JSON → persist to Graphiti → summarize
+
+## Phase 1: ANCHOR — Entity Resolution
+
+**Goal**: Resolve every gene, drug, and disease in the user's query to canonical CURIEs.
+
+**LOCATE** (always start with HGNC for genes — fastest, most reliable):
+
+PRIMARY (MCP tool):
+```
+Call `hgnc_search_genes` with: {"query": "TP53"}
+→ Returns candidates with HGNC IDs → select best match: HGNC:11998
 ```
 
+FALLBACK (curl):
 ```bash
-# Curl: Open Targets (gene-disease)
+curl -s "https://rest.genenames.org/search/symbol/TP53" \
+  -H "Accept: application/json" | jq '.response.docs[0] | {hgnc_id, symbol, name}'
+```
+
+**RETRIEVE** (get full record with cross-references):
+
+PRIMARY (MCP tool):
+```
+Call `hgnc_get_gene` with: {"hgnc_id": "HGNC:11998"}
+→ Returns: symbol, name, UniProt cross-ref, Ensembl cross-ref, Entrez cross-ref
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://rest.genenames.org/fetch/hgnc_id/11998" \
+  -H "Accept: application/json" | jq '.response.docs[0]'
+```
+
+**For drugs** (try ChEMBL search, note failure for Phase 4a fallback):
+
+PRIMARY (MCP tool):
+```
+Call `chembl_search_compounds` with: {"query": "Venetoclax"}
+→ If 500 error: note it, move on — drugs resolved in Phase 4a via Open Targets
+```
+
+**For diseases** (use ClinicalTrials.gov or Open Targets search):
+
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_search_trials` with: {"query": "fibrodysplasia ossificans progressiva"}
+```
+
+**Output**: JSON with resolved entities:
+```json
+{
+  "entities": [
+    {"mention": "TP53", "type": "Gene", "curie": "HGNC:11998", "symbol": "TP53", "status": "resolved"},
+    {"mention": "FOP", "type": "Disease", "curie": "MONDO:0018875", "status": "resolved"}
+  ],
+  "unresolved": []
+}
+```
+
+## Phase 2: ENRICH — Metadata Enrichment
+
+**Goal**: Decorate each resolved entity with metadata and cross-references. UniProt function text is the most valuable output.
+
+**RETRIEVE** gene metadata (captures cross-references for downstream phases):
+
+PRIMARY (MCP tool):
+```
+Call `hgnc_get_gene` with: {"hgnc_id": "HGNC:11998"}
+→ Extract: uniprot_id="P04637", ensembl_id="ENSG00000141510", entrez_id="7157"
+```
+
+**RETRIEVE** protein function (reveals interactors, pathways, disease connections):
+
+PRIMARY (MCP tool):
+```
+Call `uniprot_get_protein` with: {"uniprot_id": "P04637"}
+→ Parse function text for interactor mentions: BAX, BCL2, FAS, MDM2
+```
+
+**RETRIEVE** drug metadata (if drug was resolved in Phase 1):
+
+PRIMARY (MCP tool):
+```
+Call `chembl_get_compound` with: {"chembl_id": "CHEMBL3137309"}
+→ May return 500 — note failure, continue
+```
+
+**Critical outputs for downstream phases**:
+- Ensembl ID (ENSG...) → needed by Phase 4a for Open Targets GraphQL
+- UniProt ID → needed by Phase 3 for STRING
+- Interactor mentions from function text → guides Phase 3 expansion
+
+## Phase 3: EXPAND — Network Expansion
+
+**Goal**: Build adjacency list from interaction databases.
+
+**LOCATE** STRING protein ID:
+
+PRIMARY (MCP tool):
+```
+Call `string_search_proteins` with: {"query": "TP53", "species": 9606}
+→ Returns: 9606.ENSP00000269305
+```
+
+**RETRIEVE** protein interactions:
+
+PRIMARY (MCP tool):
+```
+Call `string_get_interactions` with: {"string_id": "9606.ENSP00000269305", "species": 9606, "required_score": 700}
+→ Returns: MDM2 (0.999), SIRT1 (0.999), ATM (0.995), BCL2
+```
+
+**RETRIEVE** pathway membership:
+
+PRIMARY (MCP tool):
+```
+Call `wikipathways_get_pathways_for_gene` with: {"gene_id": "TP53"}
+```
+
+**RETRIEVE** gene-disease associations (Open Targets):
+
+PRIMARY (MCP tool):
+```
+Call `opentargets_get_associations` with: {"ensembl_id": "ENSG00000141510"}
+→ Returns associated diseases with scores
+```
+
+FALLBACK (curl — for custom GraphQL queries):
+```bash
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ target(ensemblId: \"ENSG00000141510\") { associatedDiseases(page: {size: 5}) { rows { disease { name } score } } } }"}'
+  -d '{"query": "{ target(ensemblId: \"ENSG00000141510\") { associatedDiseases(page: {index: 0, size: 5}) { rows { disease { name id } score } } } }"}'
 ```
 
-### Phase 4: Target Traversal (Pharma)
+**Pitfalls**:
+- STRING batch queries (multiple proteins) return protein names; single queries may NOT. Prefer batch.
+- STRING rate limit is 1 req/s.
+- Always use `species=9606` (human) unless explicitly doing comparative genomics.
+- BioGRID requires `BIOGRID_API_KEY` — check with `grep BIOGRID_API_KEY .env`.
 
-Follow edges to actionable targets.
+## Phase 4a: TRAVERSE_DRUGS — Drug Discovery
 
-```python
-# MCP: HGNC (resolve downstream effector)
-bcl2 = hgnc.search_genes("BCL2")  # → HGNC:990
+**Goal**: Find drugs targeting identified proteins. Open Targets is the PRIMARY source (more reliable than ChEMBL).
 
-# MCP: ChEMBL (find inhibitors)
-venetoclax = chembl.search_compounds("Venetoclax")  # → CHEMBL:3137309
+**LOCATE** drugs via Open Targets (preferred — returns drugs + mechanisms + phases in one call):
+
+PRIMARY (MCP tool):
+```
+Call `opentargets_get_target` with: {"ensembl_id": "ENSG00000171791"}
+→ Returns knownDrugs with drug name, mechanismOfAction, phase
 ```
 
+FALLBACK (curl — for full GraphQL control):
 ```bash
-# Curl: ChEMBL mechanism (Drug → Target edge)
-curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?molecule_chembl_id=CHEMBL3137309&format=json" \
-  | jq '.mechanisms[] | {action: .action_type, target: .target_chembl_id}'
-# → INHIBITOR → CHEMBL4860 (BCL2)
+curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { knownDrugs(page: {index: 0, size: 10}) { rows { drug { name id } mechanismOfAction phase } } } }"}'
 ```
 
-### Phase 5: Persist Graph
+**LOCATE** drugs via ChEMBL (secondary fallback — frequently 500s on detail endpoints):
 
-Store validated subgraph in Graphiti.
+PRIMARY (MCP tool):
+```
+Call `chembl_search_compounds` with: {"query": "BCL2 inhibitor"}
+→ Search endpoint is generally reliable
+```
 
+**Gain-of-Function Disease Filter** (CRITICAL for diseases like FOP):
+```
+For GAIN-OF-FUNCTION diseases (e.g., FOP caused by constitutive ACVR1 activation),
+you need INHIBITORS or ANTAGONISTS. Do NOT return agonists — they worsen the disease.
+
+Check the "mechanismOfAction" field from Open Targets:
+- INCLUDE: "inhibitor", "antagonist", "negative modulator", "antibody (blocking)"
+- EXCLUDE: "agonist", "positive modulator", "activator"
+```
+
+**Pitfalls**:
+- Open Targets GraphQL requires `page: {index: 0, size: N}` — omitting `index: 0` causes errors.
+- The Ensembl ID (ENSG...) is required for Open Targets target queries — get from Phase 2.
+- ChEMBL detail endpoints (`chembl_get_compound`) often return 500 errors; search endpoints (`chembl_search_compounds`) are generally reliable.
+- Do NOT retry ChEMBL more than once — switch to Open Targets.
+
+## Phase 4b: TRAVERSE_TRIALS — Clinical Trial Discovery
+
+**Goal**: Find clinical trials for identified drugs. Can run in parallel with Phase 4a.
+
+**LOCATE** trials by drug + disease:
+
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_search_trials` with: {"query": "venetoclax AND leukemia"}
+→ Returns trials with NCT IDs, phases, statuses
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://clinicaltrials.gov/api/v2/studies?query.cond=cancer&query.intr=venetoclax&pageSize=5&format=json" \
+  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId, title: .protocolSection.identificationModule.briefTitle, phase: .protocolSection.designModule.phases, status: .protocolSection.statusModule.overallStatus}'
+```
+
+**Fallback** — disease-only search (when drug-specific search returns zero):
+```bash
+curl -s "https://clinicaltrials.gov/api/v2/studies?query.cond=fibrodysplasia+ossificans+progressiva&pageSize=10&format=json"
+```
+
+**ClinicalTrials.gov v2 Valid Parameters**:
+- `query.cond` — condition/disease
+- `query.intr` — intervention/drug
+- `query.term` — general search (supports `AREA[StudyType]INTERVENTIONAL`)
+- `filter.overallStatus` — e.g., `RECRUITING`, `COMPLETED`
+- `pageSize` — results per page
+- `format` — `json`
+
+**Invalid parameter**: `filter.studyType` does NOT exist in v2 API. Use `query.term=AREA[StudyType]INTERVENTIONAL` instead.
+
+**Pitfalls**:
+- Use SPECIFIC drug names from Phase 4a output, NOT broad terms like "inhibitor".
+- Search for each drug separately to avoid missing trials.
+- If drug-specific search returns zero, try disease-only search as fallback.
+
+## Phase 5: VALIDATE — Fact Verification
+
+**Goal**: Verify every NCT ID, drug mechanism, and gene-disease claim. Prevents hallucinations.
+
+**RETRIEVE** trial verification:
+
+PRIMARY (MCP tool):
+```
+Call `clinicaltrials_get_trial` with: {"nct_id": "NCT03312634"}
+→ If "Entity Not Found" → mark as INVALID
+```
+
+**RETRIEVE** cross-database ID verification:
+
+FALLBACK (curl — for Ensembl xrefs):
+```bash
+curl -s "https://rest.ensembl.org/xrefs/id/ENSG00000141510?content-type=application/json" \
+  | jq '.[] | select(.dbname | test("HGNC|UniProt|OMIM|RefSeq")) | {db: .dbname, id: .primary_id}'
+```
+
+**Validation checklist**:
+- [ ] Every NCT ID verified via `clinicaltrials_get_trial`
+- [ ] Drug mechanisms match what Open Targets/ChEMBL reported
+- [ ] Gene-protein ID mappings consistent across HGNC, UniProt, Ensembl
+- [ ] No entity was introduced from parametric knowledge (everything traces to a tool call)
+
+**Verdicts**: Mark each fact as `VALIDATED`, `INVALID` (with reason), or `UNVERIFIABLE`.
+
+## Phase 6: PERSIST — Graph Persistence & Summary
+
+**Goal**: Format validated graph, persist to Graphiti, provide human-readable summary.
+
+**Structure** (only include VALIDATED entities and relationships):
 ```python
-# MCP: Graphiti
-graphiti.add_memory(
+graph_data = {
+    "nodes": [
+        {"id": "HGNC:11998", "type": "Gene", "label": "TP53", "properties": {"ensembl": "ENSG00000141510"}},
+        {"id": "HGNC:990", "type": "Gene", "label": "BCL2", "properties": {"ensembl": "ENSG00000171791"}},
+        {"id": "CHEMBL:3137309", "type": "Compound", "label": "Venetoclax", "properties": {"phase": 4}}
+    ],
+    "edges": [
+        {"source": "HGNC:11998", "target": "HGNC:990", "type": "REGULATES", "properties": {}},
+        {"source": "CHEMBL:3137309", "target": "HGNC:990", "type": "INHIBITOR", "properties": {"mechanism": "BCL2 inhibitor"}}
+    ]
+}
+```
+
+**Persist** (if Graphiti is available):
+```python
+persist_to_graphiti(
     name="TP53-BCL2-Venetoclax pathway",
-    episode_body=json.dumps({
-        "nodes": [
-            {"id": "HGNC:11998", "type": "Gene", "symbol": "TP53"},
-            {"id": "HGNC:990", "type": "Gene", "symbol": "BCL2"},
-            {"id": "CHEMBL:3137309", "type": "Compound", "name": "Venetoclax"}
-        ],
-        "edges": [
-            {"source": "HGNC:11998", "target": "HGNC:990", "type": "REGULATES"},
-            {"source": "CHEMBL:3137309", "target": "HGNC:990", "type": "INHIBITOR"}
-        ]
-    }),
+    episode_body=json.dumps(graph_data),
     source="json",
     group_id="drug-repurposing"
 )
 ```
 
-## Quick Edge Discovery Commands
+**Summary format** — provide to user:
+```
+## Summary
+[Direct answer to the user's original question]
 
-| Edge Type | Curl Command |
-|-----------|--------------|
+## Resolved Entities
+| Entity | CURIE | Type |
+|--------|-------|------|
+
+## Key Findings
+- [Validated fact 1 — source: tool/API that provided it]
+
+## Drug Candidates
+| Drug | Phase | Mechanism | Source |
+|------|-------|-----------|--------|
+
+## Clinical Trials
+| NCT ID | Title | Phase | Status | Verified |
+|--------|-------|-------|--------|----------|
+
+## Confidence
+[Overall confidence and caveats]
+```
+
+## Edge Discovery Commands
+
+These curl commands are for edge types not covered by MCP tools:
+
+| Edge Type | Command |
+|-----------|---------|
 | Drug → Target | `curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?molecule_chembl_id={ID}&format=json"` |
-| Target → Drugs | `curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?target_chembl_id={ID}&format=json"` |
+| Target → Drugs | Open Targets `knownDrugs` GraphQL (preferred) or `curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?target_chembl_id={ID}&format=json"` |
 | Drug → Disease | `curl -s "https://www.ebi.ac.uk/chembl/api/data/drug_indication?molecule_chembl_id={ID}&format=json"` |
-| Gene → Disease | Open Targets GraphQL (see Phase 3) |
+| Gene → Disease | Open Targets `associatedDiseases` GraphQL |
 | Gene → Orthologs | `curl -s "https://rest.ensembl.org/homology/id/human/{ENSG}?type=orthologues&content-type=application/json"` |
 | Protein Set → GO | `curl -s "https://string-db.org/api/json/enrichment?identifiers={IDs}&species=9606"` |
 | Gene → PubMed | `curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi?dbfrom=gene&db=pubmed&id={ID}&retmode=json"` |
 
-## Example: Drug Repurposing Graph
+## Node Types
 
-Build a complete subgraph for drug repurposing analysis:
-
-```bash
-# Step 1: Anchor - Resolve gene
-# MCP: hgnc.search_genes("TP53") → HGNC:11998
-
-# Step 2: Get protein context
-# MCP: uniprot.get_protein("UniProtKB:P04637")
-# → function mentions BCL2
-
-# Step 3: Find BCL2 inhibitors
-curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?target_chembl_id=CHEMBL4860&format=json" \
-  | jq '.mechanisms[] | {drug: .molecule_chembl_id, action: .action_type}'
-
-# Step 4: Get drug indications
-curl -s "https://www.ebi.ac.uk/chembl/api/data/drug_indication?molecule_chembl_id=CHEMBL3137309&format=json" \
-  | jq '.drug_indications[:3][] | {disease: .mesh_heading, phase: .max_phase_for_ind}'
-
-# Step 5: Find clinical trials
-curl -s "https://clinicaltrials.gov/api/v2/studies?query.intr=venetoclax&filter.overallStatus=RECRUITING&pageSize=3&format=json" \
-  | jq '.studies[] | {nct: .protocolSection.identificationModule.nctId}'
-
-# Step 6: Persist to Graphiti
-# MCP: graphiti.add_memory(...)
-```
-
-## Node Types (Canonical CURIEs)
-
-| Type | CURIE Pattern | Example |
-|------|---------------|---------|
-| Gene | `HGNC:\d+` | HGNC:11998 |
-| Protein | `UniProtKB:[A-Z0-9]+` | UniProtKB:P04637 |
-| Compound | `CHEMBL:\d+` | CHEMBL:3137309 |
-| Target | `CHEMBL:\d+` | CHEMBL:4860 |
-| Disease | `EFO_\d+` or `MONDO_\d+` | EFO_0000574 |
-| Pathway | `WP:WP\d+` | WP:WP1742 |
-| Trial | `NCT:\d+` | NCT:00461032 |
+| Type | CURIE Pattern | API Argument Format |
+|------|---------------|---------------------|
+| Gene | `HGNC:\d+` | `"HGNC:11998"` (HGNC includes prefix) |
+| Protein | `UniProtKB:[A-Z0-9]+` | `"P04637"` (bare accession) |
+| Compound | `CHEMBL:\d+` | `"CHEMBL3137309"` (bare, no colon) |
+| Target | `CHEMBL:\d+` | `"CHEMBL4860"` (bare) |
+| Disease | `EFO:\d+` or `MONDO:\d+` | Varies by API |
+| Pathway | `WP:WP\d+` | `"WP1742"` (bare) |
+| Trial | `NCT\d+` | `"NCT03312634"` (bare) |
+| STRING Protein | `STRING:9606.ENSP\d+` | `"9606.ENSP00000269305"` (bare) |
 
 ## Edge Types
 
-| Edge | Source | Target | Properties |
-|------|--------|--------|------------|
-| ENCODES | Gene | Protein | - |
-| REGULATES | Gene | Gene | direction: activation/repression |
-| INTERACTS | Protein | Protein | score, evidence_type |
-| INHIBITOR | Compound | Target | Ki, IC50 |
-| AGONIST | Compound | Target | EC50 |
-| TREATS | Compound | Disease | max_phase |
-| ASSOCIATED_WITH | Gene | Disease | score, evidence_sources |
-| MEMBER_OF | Gene | Pathway | - |
+| Edge | Source → Target | Key Properties |
+|------|----------------|----------------|
+| ENCODES | Gene → Protein | — |
+| REGULATES | Gene → Gene | direction: activation/repression |
+| INTERACTS | Protein → Protein | score, evidence_type |
+| INHIBITOR | Compound → Target | Ki, IC50 |
+| AGONIST | Compound → Target | EC50 |
+| TREATS | Compound → Disease | max_phase |
+| ASSOCIATED_WITH | Gene → Disease | score, evidence_sources |
+| MEMBER_OF | Gene → Pathway | — |
+
+## API Reliability & Fallback Patterns
+
+| Primary Source | Fallback | When to Switch |
+|---------------|----------|----------------|
+| ChEMBL `chembl_get_compound` | Open Targets `opentargets_get_target` | On 500 error (common for detail endpoints) |
+| ChEMBL `chembl_search_compounds` | (generally reliable) | Retry once, then report failure |
+| STRING `string_get_interactions` | BioGRID `biogrid_get_interactions` | On <3 interactions returned |
+| WikiPathways | STRING `/enrichment` endpoint | On no pathways found |
+| ClinicalTrials.gov drug search | Disease-only search | On zero results for drug+disease |
 
 ## Query Best Practices
 
-### Gene Discovery (Human-Centric)
-- **Default to species=9606** (human) for gene/protein searches
+### Human-Centric Defaults
+- Default to `species=9606` (human) for gene/protein searches
 - Use `page_size=10` for exploration, `page_size=50` for batch operations
-- Use `slim=True` for batch operations to reduce token usage
-- Only use `organism=null` for comparative genomics across species
+- Only omit organism filter for comparative genomics across species
 
 ### Drug Discovery vs Repurposing
-- **Drug repurposing**: Use `max_phase≥2` (clinical validation, shorter approval path)
+- **Drug repurposing**: Use `phase >= 2` (clinical validation, shorter approval path)
 - **General discovery**: No phase filter (include preclinical tools, mechanism probes)
-- Check mechanisms before bioactivity data
+- **Always check mechanisms** before bioactivity data
 
-### Clinical Landscape
-- **Default status=RECRUITING** for active research
-- Use phase filter only for specific analysis:
-  - PHASE3+ for commercialization analysis
-  - PHASE1/2 for early pipeline
-  - No filter for full landscape
+### Clinical Trial Defaults
+- Default `filter.overallStatus=RECRUITING` for active research
+- No phase filter for full landscape view
+- Use phase filter only for specific analysis (PHASE3+ for commercialization)
 
 ## See Also
 
-- **lifesciences-genomics**: Ensembl, NCBI, HGNC endpoints
-- **lifesciences-proteomics**: UniProt, STRING, BioGRID endpoints
-- **lifesciences-pharmacology**: ChEMBL, PubChem, IUPHAR endpoints
-- **lifesciences-clinical**: Open Targets, ClinicalTrials.gov endpoints
+- **lifesciences-genomics**: HGNC, Ensembl, NCBI gene resolution endpoints (Phases 1-2)
+- **lifesciences-proteomics**: UniProt, STRING, BioGRID interaction endpoints (Phases 2-3)
+- **lifesciences-pharmacology**: ChEMBL, PubChem, IUPHAR, Open Targets drug endpoints (Phase 4a)
+- **lifesciences-clinical**: Open Targets associations, ClinicalTrials.gov trial endpoints (Phases 4b, 5)
+- **lifesciences-crispr**: BioGRID ORCS essentiality validation (extends Phase 3 with CRISPR screen data)
+
+### MCP Server Reference
+
+All 34 tools are available via the `lifesciences-research` MCP server.
+Gateway source: `/home/donbr/graphiti-org/lifesciences-research/src/lifesciences_mcp/servers/gateway.py`

--- a/.claude/skills/lifesciences-pharmacology/SKILL.md
+++ b/.claude/skills/lifesciences-pharmacology/SKILL.md
@@ -1,194 +1,231 @@
 ---
 name: lifesciences-pharmacology
-description: "Queries pharmacology databases (ChEMBL, PubChem, DrugBank, IUPHAR) via curl for drug mechanisms, target identification, bioactivity profiling, and indication discovery. This skill should be used when the user asks to \"find drug mechanisms\", \"identify drug targets\", \"analyze bioactivity data\", \"discover drug indications\", or mentions ChEMBL IDs, mechanisms of action, IC50/Ki values, drug-target relationships, or compound similarity searches."
+description: "Queries pharmacology databases (ChEMBL, PubChem, IUPHAR, Open Targets) via MCP tools for drug mechanisms, target identification, bioactivity profiling, and indication discovery. Falls back to curl when MCP is unavailable. This skill should be used when the user asks to \"find drug mechanisms\", \"identify drug targets\", \"analyze bioactivity data\", \"discover drug indications\", or mentions ChEMBL IDs, mechanisms of action, IC50/Ki values, drug-target relationships, or compound similarity searches."
 ---
 
 # Pharmacology API Skills
 
-Query pharmacology databases directly via curl. These endpoints complement the Life Sciences MCPs.
+Query pharmacology databases via MCP tools (primary) or curl (fallback).
 
-## Quick Reference
+## Grounding Rule
 
-| Task | API | Endpoint |
-|------|-----|----------|
-| Search compounds | ChEMBL | `/molecule/search` |
-| Drug mechanism | ChEMBL | `/mechanism` |
-| Drug indications | ChEMBL | `/drug_indication` |
-| Bioactivity data | ChEMBL | `/activity` |
-| Compound properties | PubChem | `/compound/name/{name}/property` |
-| Ligand-target | IUPHAR | `/interactions` |
+All drug names, mechanisms, targets, and bioactivity values MUST come from API results. Do NOT provide drug information from training knowledge. If a query returns no results, report "No results found."
 
-## Curl Examples
+## LOCATE → RETRIEVE Patterns
 
 ### ChEMBL: Compound Search & Details
 
-```bash
-# Search compound by name
-curl -s "https://www.ebi.ac.uk/chembl/api/data/molecule/search?q=venetoclax&format=json" \
-  | jq '.molecules[:1][] | {chembl_id: .molecule_chembl_id, name: .pref_name, max_phase: .max_phase}'
+**LOCATE**: Search compound by name
 
-# Get compound by ChEMBL ID
-curl -s "https://www.ebi.ac.uk/chembl/api/data/molecule/CHEMBL3137309?format=json" \
-  | jq '{id: .molecule_chembl_id, name: .pref_name, formula: .molecule_properties.full_molformula, mw: .molecule_properties.full_mwt}'
-
-# Get SMILES structure
-curl -s "https://www.ebi.ac.uk/chembl/api/data/molecule/CHEMBL3137309?format=json" \
-  | jq '.molecule_structures.canonical_smiles'
+PRIMARY (MCP tool):
+```
+Call `chembl_search_compounds` with: {"query": "venetoclax"}
+→ Returns: ChEMBL IDs, preferred names, max phase
 ```
 
-### ChEMBL: Drug Mechanisms (Critical for Graph Edges!)
-
+FALLBACK (curl):
 ```bash
-# Get mechanism for drug (Drug → Target edge)
+curl -s "https://www.ebi.ac.uk/chembl/api/data/molecule/search?q=venetoclax&format=json" \
+  | jq '.molecules[:1][] | {chembl_id: .molecule_chembl_id, name: .pref_name, max_phase: .max_phase}'
+```
+
+**RETRIEVE**: Get compound by ChEMBL ID
+
+PRIMARY (MCP tool):
+```
+Call `chembl_get_compound` with: {"chembl_id": "CHEMBL3137309"}
+→ May return 500 error (common for detail endpoints) — fall back to Open Targets
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://www.ebi.ac.uk/chembl/api/data/molecule/CHEMBL3137309?format=json" \
+  | jq '{id: .molecule_chembl_id, name: .pref_name, formula: .molecule_properties.full_molformula, mw: .molecule_properties.full_mwt}'
+```
+
+### Open Targets: Drug Discovery (PRIMARY — More Reliable Than ChEMBL)
+
+**LOCATE**: Find drugs targeting a protein
+
+PRIMARY (MCP tool):
+```
+Call `opentargets_get_target` with: {"ensembl_id": "ENSG00000171791"}
+→ Returns: knownDrugs with drug name, mechanismOfAction, phase in one call
+```
+
+FALLBACK (curl):
+```bash
+curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { knownDrugs(page: {index: 0, size: 10}) { rows { drug { name id } mechanismOfAction phase } } } }"}'
+```
+
+**Note**: Requires Ensembl Gene ID (ENSG...). Get this from HGNC cross-references or Ensembl lookup.
+
+### ChEMBL: Drug Mechanisms (Critical for Graph Edges) — curl only
+
+**RETRIEVE**: Get mechanism for drug (Drug → Target edge)
+```bash
 curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?molecule_chembl_id=CHEMBL3137309&format=json" \
   | jq '.mechanisms[] | {action: .action_type, mechanism: .mechanism_of_action, target_id: .target_chembl_id}'
+```
 
-# Reverse: Find all drugs for target (Target → Drugs edge)
+**RETRIEVE**: Find all drugs for target (Target → Drugs edge)
+```bash
 curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?target_chembl_id=CHEMBL4860&format=json" \
   | jq '.mechanisms[] | {drug_id: .molecule_chembl_id, action: .action_type, mechanism: .mechanism_of_action}'
 ```
 
-### ChEMBL: Drug Indications
+### ChEMBL: Drug Indications — curl only
 
+**RETRIEVE**: Get indications for drug (Drug → Disease edge)
 ```bash
-# Get indications for drug (Drug → Disease edge)
 curl -s "https://www.ebi.ac.uk/chembl/api/data/drug_indication?molecule_chembl_id=CHEMBL3137309&format=json" \
   | jq '.drug_indications[:5][] | {disease: .mesh_heading, efo: .efo_term, phase: .max_phase_for_ind}'
 ```
 
-### ChEMBL: Bioactivity Data (Potency Metrics)
+### ChEMBL: Bioactivity Data (Potency Metrics) — curl only
 
+**RETRIEVE**: Get activity data (IC50, Ki, EC50)
 ```bash
-# Get activity data (IC50, Ki, EC50)
 curl -s "https://www.ebi.ac.uk/chembl/api/data/activity?molecule_chembl_id=CHEMBL3137309&format=json&limit=10" \
   | jq '.activities[] | {target: .target_pref_name, type: .standard_type, value: .standard_value, units: .standard_units}'
-
-# Filter by activity type
-curl -s "https://www.ebi.ac.uk/chembl/api/data/activity?molecule_chembl_id=CHEMBL3137309&standard_type=Ki&format=json" \
-  | jq '.activities[] | {target: .target_pref_name, Ki: .standard_value, units: .standard_units}'
-
-# Get activities for target
-curl -s "https://www.ebi.ac.uk/chembl/api/data/activity?target_chembl_id=CHEMBL4860&format=json&limit=10" \
-  | jq '.activities[] | {compound: .molecule_chembl_id, type: .standard_type, value: .standard_value}'
-```
-
-### ChEMBL: Structure Search
-
-```bash
-# Similarity search (find analogs)
-SMILES="CC1=CC=CC=C1"  # Example SMILES
-curl -s "https://www.ebi.ac.uk/chembl/api/data/similarity/$SMILES/70?format=json" \
-  | jq '.molecules[:3][] | {id: .molecule_chembl_id, name: .pref_name, similarity: .similarity}'
-
-# Substructure search
-curl -s "https://www.ebi.ac.uk/chembl/api/data/substructure/$SMILES?format=json&limit=5" \
-  | jq '.molecules[] | {id: .molecule_chembl_id, name: .pref_name}'
-```
-
-### ChEMBL: Target Information
-
-```bash
-# Get target details
-curl -s "https://www.ebi.ac.uk/chembl/api/data/target/CHEMBL4860?format=json" \
-  | jq '{id: .target_chembl_id, name: .pref_name, type: .target_type, organism: .organism}'
-
-# Search targets by gene
-curl -s "https://www.ebi.ac.uk/chembl/api/data/target/search?q=BCL2&format=json" \
-  | jq '.targets[:3][] | {id: .target_chembl_id, name: .pref_name, type: .target_type}'
 ```
 
 ### PubChem: Compound Data
 
+**LOCATE**: Get compound by name
+
+PRIMARY (MCP tool):
+```
+Call `pubchem_search_compounds` with: {"query": "aspirin"}
+→ Returns: CID, molecular formula, properties
+```
+
+FALLBACK (curl):
 ```bash
-# Get compound by name
 curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/aspirin/JSON" \
   | jq '.PC_Compounds[0] | {cid: .id.id.cid}'
+```
 
-# Get properties
-curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/aspirin/property/MolecularFormula,MolecularWeight,IUPACName/JSON" \
+**RETRIEVE**: Get properties by CID
+
+PRIMARY (MCP tool):
+```
+Call `pubchem_get_compound` with: {"cid": "2244"}
+→ Returns: molecular formula, weight, IUPAC name
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/2244/property/MolecularFormula,MolecularWeight,IUPACName/JSON" \
   | jq '.PropertyTable.Properties[0]'
-
-# Get by CID
-curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/2244/property/MolecularFormula,CanonicalSMILES/JSON" \
-  | jq '.PropertyTable.Properties[0]'
-
-# Cross-references
-curl -s "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/2244/xrefs/RegistryID/JSON" \
-  | jq '.InformationList.Information[0].RegistryID[:5]'
 ```
 
 ### IUPHAR/GtoPdb: Pharmacology
 
+**LOCATE**: Search ligands
+
+PRIMARY (MCP tool):
+```
+Call `iuphar_search_ligands` with: {"query": "ibuprofen"}
+→ Returns: ligand ID, name, type, approved status
+```
+
+FALLBACK (curl):
 ```bash
-# Search ligands (drugs/compounds)
 curl -s "https://www.guidetopharmacology.org/services/ligands?name=ibuprofen" \
   | jq '.[:1][] | {id: .ligandId, name, type, approved}'
+```
 
-# Get ligand details
-curl -s "https://www.guidetopharmacology.org/services/ligands/2713" \
-  | jq '{id: .ligandId, name, type, approved, synonyms}'
+**RETRIEVE**: Get ligand-target interactions
 
-# Search targets
-curl -s "https://www.guidetopharmacology.org/services/targets?name=dopamine" \
-  | jq '.[:3][] | {id: .targetId, name, type: .type}'
+PRIMARY (MCP tool):
+```
+Call `iuphar_get_ligand` with: {"ligand_id": "2713"}
+→ Returns: target interactions, action types, affinities
+```
 
-# Get target-ligand interactions
+FALLBACK (curl):
+```bash
 curl -s "https://www.guidetopharmacology.org/services/ligands/2713/interactions" \
   | jq '.[:3][] | {target: .targetName, action: .action, affinity}'
 ```
 
-### DrugBank: Drug Data (API Key Required)
+## Drug Repurposing Workflow (LOCATE → RETRIEVE Chain)
 
 ```bash
-# Search drugs (commercial API)
-curl -s "https://api.drugbank.com/v1/drugs?q=venetoclax" \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  | jq '.[:1][] | {drugbank_id, name, description}'
-```
-
-## Common Workflow: Drug Repurposing
-
-```bash
-# 1. Find target for known drug
+# Step 1: LOCATE — Find target for known drug (curl — mechanism endpoint)
 TARGET=$(curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?molecule_chembl_id=CHEMBL3137309&format=json" \
   | jq -r '.mechanisms[0].target_chembl_id')
 
-# 2. Find other drugs for same target
+# Step 2: RETRIEVE — Find other drugs for same target
 curl -s "https://www.ebi.ac.uk/chembl/api/data/mechanism?target_chembl_id=$TARGET&format=json" \
   | jq '.mechanisms[] | {drug: .molecule_chembl_id, mechanism: .mechanism_of_action}'
 
-# 3. Get indications for alternative drug
+# Step 3: RETRIEVE — Get indications for alternative drug
 curl -s "https://www.ebi.ac.uk/chembl/api/data/drug_indication?molecule_chembl_id=CHEMBL2107358&format=json" \
   | jq '.drug_indications[:3][] | {disease: .mesh_heading, phase: .max_phase_for_ind}'
 ```
 
+## Quick Reference
+
+| Task | Pattern | MCP Tool (primary) | Curl Endpoint (fallback) |
+|------|---------|-------------------|--------------------------|
+| Search compounds | LOCATE | `chembl_search_compounds` | ChEMBL `/molecule/search` |
+| Get compound | RETRIEVE | `chembl_get_compound` | ChEMBL `/molecule/{id}` |
+| Drug mechanism | RETRIEVE | (curl only) | ChEMBL `/mechanism` |
+| Drug indications | RETRIEVE | (curl only) | ChEMBL `/drug_indication` |
+| Bioactivity data | RETRIEVE | (curl only) | ChEMBL `/activity` |
+| Find drugs for target | LOCATE | `opentargets_get_target` | Open Targets GraphQL `knownDrugs` |
+| Compound by name | LOCATE | `pubchem_search_compounds` | PubChem `/compound/name/{name}` |
+| Ligand interactions | RETRIEVE | `iuphar_get_ligand` | IUPHAR `/ligands/{id}/interactions` |
+
+## ID Format Reference
+
+| Database | API Argument (bare) | Graph CURIE | Example |
+|----------|---------------------|-------------|---------|
+| ChEMBL compound | `CHEMBL3137309` | `CHEMBL:3137309` | Bare for API (no colon) |
+| ChEMBL target | `CHEMBL4860` | `CHEMBL:4860` | Same pattern |
+| PubChem | `2244` (CID) | `PubChem:2244` | Bare numeric for API |
+
+## API Reliability & Fallback Patterns
+
+| Primary | Fallback | When to Switch |
+|---------|----------|----------------|
+| ChEMBL `chembl_get_compound` (detail) | Open Targets `opentargets_get_target` | On HTTP 500 (common for detail endpoints) |
+| ChEMBL `chembl_search_compounds` (search) | (generally reliable — uses Elasticsearch) | Retry once, then report failure |
+| ChEMBL `/mechanism` | Open Targets `mechanismOfAction` field | On HTTP 500 |
+
+**Critical**: ChEMBL **detail endpoints** (`/molecule/{id}`) frequently return 500 errors (EBI server issues). ChEMBL **search endpoints** (`/molecule/search?q=...`) are generally reliable because they use Elasticsearch. When detail fails, use Open Targets as primary drug discovery source.
+
 ## Rate Limits
 
-| API | Limit | Auth Required |
-|-----|-------|---------------|
-| ChEMBL | 100 req/s | No |
-| PubChem | 5 req/s | No |
-| DrugBank | Varies | Yes (commercial) |
-| IUPHAR | 10 req/s | No |
+| API | Limit | Auth Required | Production Throttle |
+|-----|-------|---------------|---------------------|
+| ChEMBL | ~2 req/s | No | 0.5s delay in production |
+| PubChem | 5 req/s | No | — |
+| IUPHAR | 10 req/s | No | — |
 
 ## Query Best Practices
 
 ### Drug Discovery vs Repurposing
-- **Drug repurposing**: Use `max_phase≥2` filter (want clinical validation, shorter approval path)
+- **Drug repurposing**: Use `max_phase >= 2` filter (want clinical validation, shorter approval path)
 - **General discovery**: No phase filter (include preclinical tools, mechanism probes, research reagents)
 - **Target validation**: No phase filter needed for mechanism studies
+
+### Gain-of-Function Disease Filter
+For diseases caused by protein overactivation (e.g., FOP from constitutive ACVR1):
+- INCLUDE: inhibitors, antagonists, negative modulators
+- EXCLUDE: agonists, positive modulators, activators
+- Check `mechanismOfAction` field from Open Targets or `action_type` from ChEMBL
 
 ### Query Efficiency
 - Check mechanisms (`/mechanism` endpoint) before bioactivity data
 - Use `target_chembl_id` for reverse lookups (find drugs for target)
 - Limit activity queries with `&limit=10` for exploration
 
-### Common Pitfalls
-- Don't filter by phase for mechanism discovery
-- Don't assume approved drugs are the only useful compounds
-- Preclinical tool compounds often have better selectivity data
-
 ## See Also
 
-- [references/chembl-resources.md](references/chembl-resources.md) - ChEMBL resource endpoints
-- [references/pubchem-pug.md](references/pubchem-pug.md) - PubChem PUG REST syntax
+- **lifesciences-graph-builder**: Orchestrator for full Fuzzy-to-Fact protocol
+- **lifesciences-clinical**: Open Targets, ClinicalTrials.gov clinical endpoints

--- a/.claude/skills/lifesciences-proteomics/SKILL.md
+++ b/.claude/skills/lifesciences-proteomics/SKILL.md
@@ -1,124 +1,183 @@
 ---
 name: lifesciences-proteomics
-description: "Queries protein databases (UniProt, STRING, BioGRID) via curl for protein lookups, protein-protein interactions, functional enrichment analysis, and cross-database ID mapping. This skill should be used when the user asks to \"find protein interactions\", \"analyze interaction networks\", \"perform GO enrichment\", \"map protein IDs\", or mentions PPI networks, UniProt accessions, STRING scores, BioGRID interactions, or protein ID conversion between databases."
+description: "Queries protein databases (UniProt, STRING, BioGRID) via MCP tools for protein lookups, protein-protein interactions, functional enrichment analysis, and cross-database ID mapping. Falls back to curl when MCP is unavailable. This skill should be used when the user asks to \"find protein interactions\", \"analyze interaction networks\", \"perform GO enrichment\", \"map protein IDs\", or mentions PPI networks, UniProt accessions, STRING scores, BioGRID interactions, or protein ID conversion between databases."
 ---
 
 # Proteomics API Skills
 
-Query protein databases directly via curl. These endpoints complement the Life Sciences MCPs.
+Query protein databases via MCP tools (primary) or curl (fallback).
 
-## Quick Reference
+## Grounding Rule
 
-| Task | API | Endpoint |
-|------|-----|----------|
-| Search proteins | UniProt | `/uniprotkb/search` |
-| Get protein details | UniProt | `/uniprotkb/{accession}` |
-| Batch ID mapping | UniProt | `/idmapping/run` |
-| Protein interactions | STRING | `/network` |
-| Functional enrichment | STRING | `/enrichment` |
-| Genetic/physical interactions | BioGRID | `/interactions` |
+All protein names, interaction partners, and scores MUST come from API results. Do NOT list protein interactions from training knowledge. If a query returns no results, report "No results found."
 
-## Curl Examples
+## LOCATE → RETRIEVE Patterns
 
 ### UniProt: Protein Search & Retrieval
 
-```bash
-# Search for protein by gene name
-curl -s "https://rest.uniprot.org/uniprotkb/search?query=gene:TP53+AND+organism_id:9606&format=json&size=3" \
-  | jq '.results[:1][] | {accession: .primaryAccession, name: .proteinDescription.recommendedName.fullName.value}'
+**LOCATE**: Search for protein by gene name
 
-# Get protein by accession
-curl -s "https://rest.uniprot.org/uniprotkb/P04637.json" \
-  | jq '{accession: .primaryAccession, gene: .genes[0].geneName.value, function: .comments[] | select(.commentType=="FUNCTION") | .texts[0].value}'
-
-# Get protein sequence (FASTA)
-curl -s "https://rest.uniprot.org/uniprotkb/P04637.fasta"
-
-# Search with field queries
-curl -s "https://rest.uniprot.org/uniprotkb/search?query=reviewed:true+AND+organism_id:9606+AND+keyword:Apoptosis&format=json&size=5" \
-  | jq '.results[] | {accession: .primaryAccession, gene: .genes[0].geneName.value}'
+PRIMARY (MCP tool):
+```
+Call `uniprot_search_proteins` with: {"query": "TP53", "organism": "9606"}
+→ Returns protein accessions, names, gene names
 ```
 
-### UniProt: Batch ID Mapping (Async)
-
+FALLBACK (curl):
 ```bash
-# Submit ID mapping job
+curl -s "https://rest.uniprot.org/uniprotkb/search?query=gene:TP53+AND+organism_id:9606&format=json&size=3" \
+  | jq '.results[:1][] | {accession: .primaryAccession, name: .proteinDescription.recommendedName.fullName.value}'
+```
+
+**RETRIEVE**: Get protein by accession (function text is most valuable output)
+
+PRIMARY (MCP tool):
+```
+Call `uniprot_get_protein` with: {"uniprot_id": "P04637"}
+→ Returns: accession, gene, function text, cross-references
+→ Parse function text for interactor mentions and pathway clues
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://rest.uniprot.org/uniprotkb/P04637.json" \
+  | jq '{accession: .primaryAccession, gene: .genes[0].geneName.value, function: .comments[] | select(.commentType=="FUNCTION") | .texts[0].value}'
+```
+
+**RETRIEVE**: Get protein sequence (FASTA) — curl only
+```bash
+curl -s "https://rest.uniprot.org/uniprotkb/P04637.fasta"
+```
+
+### UniProt: Batch ID Mapping (Async) — curl only
+
+**LOCATE** + **RETRIEVE** (two-step async pattern):
+```bash
+# Step 1: Submit ID mapping job
 JOB_ID=$(curl -s "https://rest.uniprot.org/idmapping/run" \
   --form 'ids=P04637,P38398,P51587' \
   --form 'from=UniProtKB_AC-ID' \
   --form 'to=Ensembl' | jq -r '.jobId')
 
-# Check job status
+# Step 2: Check status then get results
 curl -s "https://rest.uniprot.org/idmapping/status/$JOB_ID"
-
-# Get results (when complete)
 curl -s "https://rest.uniprot.org/idmapping/results/$JOB_ID" | jq '.results'
 ```
 
 ### STRING: Protein-Protein Interactions
 
-```bash
-# Get interaction network for proteins
-curl -s "https://string-db.org/api/json/network?identifiers=TP53&species=9606&required_score=700&limit=10" \
-  | jq '.[] | {proteinA: .preferredName_A, proteinB: .preferredName_B, score}'
+**LOCATE**: Resolve gene symbol to STRING ID
 
-# Network for multiple proteins
-curl -s "https://string-db.org/api/json/network?identifiers=TP53%0dMDM2%0dATM&species=9606" \
-  | jq '.[] | {A: .preferredName_A, B: .preferredName_B, score}'
-
-# Get evidence scores breakdown
-curl -s "https://string-db.org/api/json/network?identifiers=TP53&species=9606&required_score=900&limit=5" \
-  | jq '.[] | {A: .preferredName_A, B: .preferredName_B, experimental: .escore, database: .dscore, textmining: .tscore}'
+PRIMARY (MCP tool):
+```
+Call `string_search_proteins` with: {"query": "TP53", "species": 9606}
+→ Returns: 9606.ENSP00000269305
 ```
 
-### STRING: Functional Enrichment
-
+FALLBACK (curl):
 ```bash
-# GO/KEGG/Reactome enrichment for protein set
+curl -s "https://string-db.org/api/json/get_string_ids?identifiers=TP53&species=9606" \
+  | jq '.[0].stringId'
+```
+
+**RETRIEVE**: Get interaction network
+
+PRIMARY (MCP tool):
+```
+Call `string_get_interactions` with: {"string_id": "9606.ENSP00000269305", "species": 9606, "required_score": 700}
+→ Returns: interaction partners with confidence scores
+```
+
+FALLBACK (curl):
+```bash
+curl -s "https://string-db.org/api/json/network?identifiers=TP53&species=9606&required_score=700&limit=10" \
+  | jq '.[] | {proteinA: .preferredName_A, proteinB: .preferredName_B, score}'
+```
+
+**RETRIEVE**: Network for multiple proteins (batch — returns protein names in response)
+```bash
+curl -s "https://string-db.org/api/json/network?identifiers=TP53%0dMDM2%0dATM&species=9606" \
+  | jq '.[] | {A: .preferredName_A, B: .preferredName_B, score}'
+```
+
+### STRING: Functional Enrichment — curl only
+
+**RETRIEVE**: GO/KEGG/Reactome enrichment for protein set
+```bash
 curl -s "https://string-db.org/api/json/enrichment?identifiers=9606.ENSP00000269305%0d9606.ENSP00000258149%0d9606.ENSP00000278616&species=9606" \
   | jq '.[:5][] | {category, term, description, fdr}'
-
-# Enrichment with gene symbols (need to resolve first)
-curl -s "https://string-db.org/api/json/get_string_ids?identifiers=TP53%0dMDM2%0dATM&species=9606" \
-  | jq '.[].stringId' # Use these IDs for enrichment
 ```
 
 ### STRING: Network Visualization
 
-```bash
-# Get network image URL
-echo "https://string-db.org/api/highres_image/network?identifiers=TP53%0dMDM2%0dATM&species=9606&network_flavor=confidence"
+PRIMARY (MCP tool):
+```
+Call `string_get_network_image_url` with: {"identifiers": ["TP53", "MDM2", "ATM"], "species": 9606}
+→ Returns URL for network image
+```
 
-# Get SVG
-curl -s "https://string-db.org/api/svg/network?identifiers=TP53&species=9606&add_nodes=5" > network.svg
+FALLBACK (curl):
+```bash
+echo "https://string-db.org/api/highres_image/network?identifiers=TP53%0dMDM2%0dATM&species=9606&network_flavor=confidence"
 ```
 
 ### BioGRID: Genetic & Physical Interactions
 
+**LOCATE**: Search for gene interactions
+
+PRIMARY (MCP tool):
+```
+Call `biogrid_search_genes` with: {"query": "TP53"}
+→ Returns BioGRID gene entries
+```
+
+**RETRIEVE**: Get interactions for gene
+
+PRIMARY (MCP tool):
+```
+Call `biogrid_get_interactions` with: {"gene_id": "TP53", "organism": 9606}
+→ Returns: interaction partners, experimental systems
+```
+
+FALLBACK (curl — requires API key):
 ```bash
-# Get interactions for gene (requires API key)
 curl -s "https://webservice.thebiogrid.org/interactions?geneList=TP53&taxId=9606&format=json&accesskey=${BIOGRID_API_KEY}" \
   | jq 'to_entries[:5][] | .value | {geneA: .OFFICIAL_SYMBOL_A, geneB: .OFFICIAL_SYMBOL_B, system: .EXPERIMENTAL_SYSTEM}'
-
-# Filter by experimental method
-curl -s "https://webservice.thebiogrid.org/interactions?geneList=TP53&taxId=9606&evidenceList=Two-hybrid&format=json&accesskey=${BIOGRID_API_KEY}"
-
-# Low-throughput only (higher confidence)
-curl -s "https://webservice.thebiogrid.org/interactions?geneList=TP53&taxId=9606&throughputTag=low&format=json&accesskey=${BIOGRID_API_KEY}"
 ```
 
 ## ID Resolution Patterns
 
-```bash
-# Gene symbol → STRING ID
-curl -s "https://string-db.org/api/json/get_string_ids?identifiers=TP53&species=9606" \
-  | jq '.[0].stringId'
-# Output: "9606.ENSP00000269305"
+### Gene Symbol → STRING ID → UniProt (LOCATE chain)
 
-# STRING ID → UniProt
+```
+# Step 1: Gene symbol → STRING ID (MCP LOCATE)
+Call `string_search_proteins` with: {"query": "TP53", "species": 9606}
+→ "9606.ENSP00000269305"
+
+# Step 2: STRING ID → UniProt (curl RETRIEVE via Ensembl xrefs)
 curl -s "https://rest.ensembl.org/xrefs/id/ENSP00000269305?content-type=application/json" \
   | jq '.[] | select(.dbname=="Uniprot/SWISSPROT") | .primary_id'
 ```
+
+## Quick Reference
+
+| Task | Pattern | MCP Tool (primary) | Curl Endpoint (fallback) |
+|------|---------|-------------------|--------------------------|
+| Search proteins | LOCATE | `uniprot_search_proteins` | UniProt `/uniprotkb/search` |
+| Get protein details | RETRIEVE | `uniprot_get_protein` | UniProt `/uniprotkb/{accession}` |
+| Batch ID mapping | LOCATE+RETRIEVE | (curl only) | UniProt `/idmapping/run` |
+| Resolve to STRING ID | LOCATE | `string_search_proteins` | STRING `/get_string_ids` |
+| Protein interactions | RETRIEVE | `string_get_interactions` | STRING `/network` |
+| Functional enrichment | RETRIEVE | (curl only) | STRING `/enrichment` |
+| Gene interactions | RETRIEVE | `biogrid_get_interactions` | BioGRID `/interactions` |
+
+## ID Format Reference
+
+| Database | API Argument (bare) | Graph CURIE | Example |
+|----------|---------------------|-------------|---------|
+| UniProt | `P04637` | `UniProtKB:P04637` | Bare accession for API |
+| STRING | `9606.ENSP00000269305` | `STRING:9606.ENSP00000269305` | Species prefix + Ensembl protein |
+| BioGRID | `TP53` (gene symbol) | N/A | Uses gene symbols directly |
 
 ## Rate Limits
 
@@ -127,3 +186,22 @@ curl -s "https://rest.ensembl.org/xrefs/id/ENSP00000269305?content-type=applicat
 | UniProt | 100 req/s | No |
 | STRING | 1 req/s | No |
 | BioGRID | 10 req/s | Yes (API key) |
+
+## Pitfalls
+
+- **STRING batch queries** (multiple proteins, separated by `%0d`) return protein names in response; **single-protein queries may NOT include names**.
+- **STRING rate limit is 1 req/s** — don't make rapid sequential calls.
+- **BioGRID requires `BIOGRID_API_KEY`** — check with `grep BIOGRID_API_KEY .env`.
+- **UniProt function text** is the most valuable enrichment output — parse it for interactor mentions and pathway clues.
+
+## Fallback Patterns
+
+| Primary | Fallback | When |
+|---------|----------|------|
+| STRING `string_get_interactions` | BioGRID `biogrid_get_interactions` | <3 interactions returned from STRING |
+| UniProt `uniprot_get_protein` | Ensembl xrefs + NCBI gene summary | UniProt down or no results |
+
+## See Also
+
+- **lifesciences-graph-builder**: Orchestrator for full Fuzzy-to-Fact protocol
+- **lifesciences-genomics**: HGNC, Ensembl, NCBI gene resolution endpoints

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "lifesciences-research": {
+      "type": "http",
+      "url": "https://lifesciences-research.fastmcp.app/mcp"
+    },
     "graphiti-aura": {
       "type": "stdio",
       "command": "/home/donbr/graphiti-fastmcp/scripts/run_mcp_server.sh",

--- a/docs/evaluations/behavioral-audit.md
+++ b/docs/evaluations/behavioral-audit.md
@@ -1,0 +1,187 @@
+# Behavioral Audit: Life Sciences Skills
+
+## Audit Methodology
+
+This audit analyzes what Claude Code *actually does* when each skill is invoked, compared to what the SKILL.md instructs. Analysis is based on:
+1. The ACVR1/FOP execution trace (2026-02-07 retrospective)
+2. Structural analysis of each SKILL.md for behavioral triggers
+3. Known Claude Code behavioral patterns with MCP tools vs parametric knowledge
+
+## Test Case: TP53 Pathway (Test Case #1)
+
+### Skill 1: lifesciences-genomics
+
+**Expected behavior**: Use HGNC curl to search for TP53, then fetch by HGNC ID. Use Ensembl for cross-references.
+
+**Predicted actual behavior**:
+| Step | Expected (SKILL.md) | Likely Actual | Issue |
+|------|---------------------|---------------|-------|
+| Gene search | `curl HGNC /search/symbol/TP53` | May answer "TP53 is HGNC:11998" from memory | **No LOCATE enforcement** — skill shows curl examples but doesn't mandate their use before answering |
+| Gene metadata | `curl Ensembl /lookup/id/ENSG00000141510` | May skip if already "knows" chromosome 17p13.1 | **No RETRIEVE mandate** — skill is a reference, not a workflow |
+| Cross-references | `curl Ensembl /xrefs/id/ENSG00000141510` | Likely skipped entirely | Skill lists the command but doesn't require it |
+
+**Key finding**: The genomics skill is structured as a **reference card** (API endpoint catalog) rather than a **workflow**. It provides curl examples but never says "you MUST call this before answering." Claude Code can satisfy user queries from parametric knowledge without ever touching the APIs.
+
+**LOCATE→RETRIEVE discipline**: ABSENT — no explicit two-step pattern defined.
+
+**CURIE output**: Not required — skill shows `jq` filters that extract bare IDs (e.g., `{hgnc_id, symbol, name}`), not full CURIEs.
+
+---
+
+### Skill 2: lifesciences-proteomics
+
+**Expected behavior**: Search UniProt for TP53 protein, get protein details, query STRING for interactions.
+
+**Predicted actual behavior**:
+| Step | Expected (SKILL.md) | Likely Actual | Issue |
+|------|---------------------|---------------|-------|
+| Protein search | `curl UniProt /search?query=gene:TP53` | May state "P04637 is the TP53 protein" from memory | **No LOCATE enforcement** |
+| Protein details | `curl UniProt /P04637.json` | Might call this OR might summarize from knowledge | Depends on whether user asks for specific fields |
+| STRING interactions | `curl STRING /network?identifiers=TP53` | More likely to call this (novel data) | STRING data is less likely to be memorized |
+| BioGRID interactions | `curl BioGRID /interactions?geneList=TP53` | Likely called if STRING fails | Requires API key — may fail silently |
+
+**Key finding**: Like genomics, this is a reference card. The "ID Resolution Patterns" section (lines 112-121) shows a useful LOCATE→RETRIEVE pattern (gene symbol → STRING ID → UniProt) but doesn't label it as mandatory.
+
+**LOCATE→RETRIEVE discipline**: IMPLICIT — pattern exists in examples but is not named or enforced.
+
+**CURIE output**: Inconsistent — UniProt examples return bare accessions (`P04637`), STRING returns bare IDs (`9606.ENSP00000269305`). No CURIE formatting guidance.
+
+---
+
+### Skill 3: lifesciences-pharmacology
+
+**Expected behavior**: Search ChEMBL for compounds, get mechanisms, find bioactivity data.
+
+**Predicted actual behavior**:
+| Step | Expected (SKILL.md) | Likely Actual | Issue |
+|------|---------------------|---------------|-------|
+| Compound search | `curl ChEMBL /molecule/search?q=venetoclax` | May state "Venetoclax is CHEMBL3137309" from memory | **No LOCATE enforcement** |
+| Drug mechanism | `curl ChEMBL /mechanism?molecule_chembl_id=CHEMBL3137309` | Likely called — mechanism details are novel | Good: this is a RETRIEVE step |
+| Drug indications | `curl ChEMBL /drug_indication?...` | Likely called if mechanisms succeeded | |
+| Open Targets fallback | Not documented | **MISSING** — skill doesn't mention Open Targets | Critical gap from production code |
+
+**Key finding**: The pharmacology skill has the **best workflow example** (lines 149-163: "Drug Repurposing" pattern) but it assumes you already know the ChEMBL ID. There is no guidance on what to do when ChEMBL returns 500 errors — the production code uses Open Targets as fallback, but this skill doesn't document it.
+
+**LOCATE→RETRIEVE discipline**: PARTIAL — "Drug Repurposing" workflow shows a 3-step pattern (find target → find drugs → get indications) but doesn't use LOCATE/RETRIEVE terminology.
+
+**CURIE output**: Bare ChEMBL IDs only (e.g., `CHEMBL3137309`, not `CHEMBL:3137309`).
+
+---
+
+### Skill 4: lifesciences-clinical
+
+**Expected behavior**: Query Open Targets for target-disease associations, search ClinicalTrials.gov for trials.
+
+**Predicted actual behavior**:
+| Step | Expected (SKILL.md) | Likely Actual | Issue |
+|------|---------------------|---------------|-------|
+| Target-disease | Open Targets GraphQL | Likely called — GraphQL is specific enough | Good: requires Ensembl ID (forces prior resolution) |
+| Known drugs | Open Targets `knownDrugs` | Likely called | Good: structured data, hard to guess |
+| Trial search | ClinicalTrials.gov v2 API | Likely called | API is specific enough to force tool use |
+| Trial details | ClinicalTrials.gov by NCT ID | Likely called for verification | Good |
+
+**Key finding**: This skill has the **strongest tool-use incentives** because Open Targets GraphQL requires specific Ensembl IDs and ClinicalTrials.gov returns structured JSON that Claude can't easily fabricate. However, it has a **filter documentation bug**: `filter.advanced=AREA[Phase]PHASE3` on line 121 — the correct v2 syntax is not well-documented.
+
+**LOCATE→RETRIEVE discipline**: IMPLICIT — the "Disease → Targets → Drugs → Trials" workflow (lines 177-195) is a 3-step chain but doesn't label steps as LOCATE/RETRIEVE.
+
+**CURIE output**: Uses Ensembl IDs for targets, EFO IDs for diseases — good. NCT IDs returned as bare strings.
+
+**Bug**: `knownDrugs` query on line 50 is missing `index: 0` in pagination: `page: {size: 5}` should be `page: {size: 5, index: 0}`. This may cause errors.
+
+---
+
+### Skill 5: lifesciences-crispr
+
+**Expected behavior**: Resolve gene to Entrez ID via HGNC, then query BioGRID ORCS for essentiality data.
+
+**Predicted actual behavior**:
+| Step | Expected (SKILL.md) | Likely Actual | Issue |
+|------|---------------------|---------------|-------|
+| Gene resolution | HGNC MCP → Entrez ID | Likely called — skill mandates this step | **Best LOCATE example** in all skills |
+| ORCS essential screens | `curl orcsws.thebiogrid.org/gene/{id}?hit=yes` | Likely called — data is too specific to guess | Good |
+| Screen annotations | `curl orcsws.thebiogrid.org/screens/` | Likely called — second step of workflow | Good |
+
+**Key finding**: The CRISPR skill has the **strongest workflow discipline** of all 6 skills. Phase 1 explicitly says "Resolve Gene Identifiers" and Phase 2 says "Query ORCS for Essential Screens Only". The `hit=yes` parameter is emphasized as critical. However, it doesn't use LOCATE/RETRIEVE terminology.
+
+**LOCATE→RETRIEVE discipline**: PRESENT but unnamed — Phases 1-5 form a clear sequential pipeline.
+
+**CURIE output**: Uses Entrez IDs (bare, e.g., `7298`). No CURIE formatting.
+
+---
+
+### Skill 6: lifesciences-graph-builder (Orchestrator)
+
+**Expected behavior**: Execute 7-phase Fuzzy-to-Fact protocol using MCP tools for nodes and curl for edges.
+
+**Predicted actual behavior** (based on ACVR1 trace):
+| Phase | Expected (SKILL.md) | Observed (Retrospective) | Issue |
+|-------|---------------------|--------------------------|-------|
+| 1 ANCHOR | HGNC search → get gene | HGNC search worked; over-resolved drugs | Scope creep into Phase 4a |
+| 2 ENRICH | UniProt get protein | Used PubMed instead of structured APIs | **Tier demotion**: narrative text instead of structured IDs |
+| 3 EXPAND | STRING interactions, WikiPathways | Partial — WikiPathways found paths but didn't enumerate components | Incomplete RETRIEVE step |
+| 4a DRUGS | ChEMBL/Open Targets | Open Targets returned agonists (wrong drugs for FOP) | **No mechanism filtering** for gain-of-function diseases |
+| 4b TRIALS | ClinicalTrials.gov | Searched for wrong drugs → zero results | Cascading failure from Phase 4a |
+| 5 VALIDATE | Verify NCT IDs, mechanisms | Hallucinated NCT ID from prompt example | **Hallucination injection** from parametric knowledge |
+| 6 PERSIST | Graphiti add_memory | Failed — no tools wired | **BUG**: `tools=[]` |
+
+**Key finding**: The graph-builder skill's **architecture diagram** (lines 12-35) correctly defines the three-tier pattern, but the **workflow section** (lines 37-191) doesn't enforce mandatory tool calls. Each phase shows code examples with `# MCP:` comments, but these are treated as suggestions, not requirements. The validator hallucinated entities not from upstream, proving the **external knowledge restriction** is missing.
+
+**LOCATE→RETRIEVE discipline**: IMPLICIT — Phase 1 shows search→get pattern but doesn't enforce it or label it.
+
+**CURIE output**: Defined in "Node Types" table (lines 193-204) but not enforced in workflow steps.
+
+---
+
+## Cross-Skill Behavioral Summary
+
+### Pattern: Parametric Knowledge Override
+
+All 6 skills share a common vulnerability: **Claude Code can satisfy most user queries from parametric knowledge without calling any tools.** The skills provide tool examples but never say:
+
+> "You MUST call this tool before providing any answer. If the tool returns no results, say 'No results found' — do NOT fill in from memory."
+
+This is the single most impactful gap. Per Anthropic's hallucination reduction guidance: *"Explicitly instruct Claude to only use information from provided documents [tools] and not its general knowledge."*
+
+### Pattern: Reference Card vs Workflow
+
+| Skill | Structure | LOCATE→RETRIEVE | Enforcement |
+|-------|-----------|-----------------|-------------|
+| genomics | Reference card | ABSENT | None |
+| proteomics | Reference card | IMPLICIT | None |
+| pharmacology | Reference card + workflow | PARTIAL | Weak (examples only) |
+| clinical | Reference card + workflow | IMPLICIT | Medium (requires specific IDs) |
+| crispr | 5-phase workflow | PRESENT (unnamed) | Strong (pipeline structure) |
+| graph-builder | 7-phase workflow | IMPLICIT | Weak (code comments only) |
+
+### Pattern: CURIE Inconsistency
+
+No skill produces consistent CURIEs:
+- Genomics: Bare HGNC IDs, bare Ensembl IDs
+- Proteomics: Bare UniProt accessions, bare STRING IDs
+- Pharmacology: Bare ChEMBL IDs
+- Clinical: Ensembl IDs for targets, EFO IDs for diseases, bare NCT IDs
+- CRISPR: Bare Entrez IDs
+- Graph-builder: CURIEs defined in table but not enforced in workflow
+
+### Hallucination Risk Assessment
+
+| Skill | Risk Level | Reason |
+|-------|------------|--------|
+| genomics | HIGH | All facts available in parametric knowledge; no tool-use mandate |
+| proteomics | HIGH | Common proteins well-known; interactions less so |
+| pharmacology | HIGH | Drug names/mechanisms widely known; no fallback docs |
+| clinical | MEDIUM | GraphQL requires specific IDs (forces some tool use) |
+| crispr | LOW | ORCS data is obscure enough to force API calls |
+| graph-builder | HIGH | Orchestrator — amplifies upstream hallucination risks |
+
+---
+
+## Recommendations
+
+1. **Add external knowledge restriction** to ALL skills (mandatory, per Anthropic guidance)
+2. **Convert reference cards to workflows** — genomics, proteomics, pharmacology need LOCATE→RETRIEVE structure
+3. **Label and enforce LOCATE→RETRIEVE** — use explicit two-step terminology
+4. **Standardize CURIE output** — define API context (bare IDs) vs graph context (full CURIEs) distinction
+5. **Add Open Targets fallback** to pharmacology skill
+6. **Fix `knownDrugs` pagination** — add `index: 0` to clinical skill
+7. **Add mechanism filtering** for gain-of-function diseases in graph-builder

--- a/docs/evaluations/consistency-analysis.md
+++ b/docs/evaluations/consistency-analysis.md
@@ -1,0 +1,234 @@
+# Consistency Analysis: Skills vs Production Implementation
+
+## Purpose
+
+This document compares the `.claude/skills/lifesciences-*` skill definitions against the `apps/api/` production implementation (prompts.py, lifesciences.py, mcp.py) to identify gaps, contradictions, and missing patterns.
+
+---
+
+## 1. Terminology Alignment
+
+### Tool Name Mapping
+
+| Skill Reference | Production Reference (prompts.py/mcp.py) | Match? |
+|-----------------|------------------------------------------|--------|
+| `hgnc.search_genes` (graph-builder:47) | `query_lifesciences(tool_name="hgnc_search_genes")` (prompts.py:187) | MISMATCH — skills use dot notation; production uses string parameter |
+| `uniprot.get_protein` (graph-builder:57) | `query_lifesciences(tool_name="uniprot_get_protein")` (prompts.py:230) | MISMATCH — same dot vs string issue |
+| `chembl.search_compounds` (graph-builder:84) | `query_lifesciences(tool_name="chembl_search_compounds")` (prompts.py:323) | MISMATCH — same |
+| `string.get_interactions` (graph-builder:67) | `query_lifesciences(tool_name="string_get_interactions")` (prompts.py:278) | MISMATCH — same |
+| `graphiti.add_memory` (graph-builder:124) | `persist_to_graphiti(name=..., episode_body=...)` (mcp.py:~400) | MISMATCH — different function signature |
+
+**Impact**: Claude Code uses the skill's dot notation syntax, which doesn't match how tools are actually invoked in the production agent. Users following skill examples would need to translate the syntax.
+
+**Recommendation**: Skills should use the `query_lifesciences(tool_name=..., tool_args={...})` syntax to match production, OR explicitly document the translation.
+
+### Phase Naming
+
+| Skill Phase | Production Specialist | Prompt Constant | Match? |
+|-------------|----------------------|-----------------|--------|
+| Phase 1: ANCHOR | `anchor_specialist` | `ANCHOR_SYSTEM` | YES |
+| Phase 2: ENRICH | `enrichment_specialist` | `ENRICH_SYSTEM` | YES |
+| Phase 3: EXPAND | `expansion_specialist` | `EXPAND_SYSTEM` | YES |
+| Phase 4a: TRAVERSE_DRUGS | `traversal_drugs_specialist` | `TRAVERSE_DRUGS_SYSTEM` | YES |
+| Phase 4b: TRAVERSE_TRIALS | `traversal_trials_specialist` | `TRAVERSE_TRIALS_SYSTEM` | YES |
+| Phase 5: VALIDATE | `validation_specialist` | `VALIDATE_SYSTEM` | YES |
+| Phase 6: PERSIST | `persistence_specialist` | `PERSIST_SYSTEM` | NUMBERING: skill says "Phase 6", prod says "Phase 7" in some docs |
+
+---
+
+## 2. Workflow Step Mapping
+
+### Genomics Skill ↔ ANCHOR + ENRICH Prompts
+
+| Genomics Skill Step | ANCHOR_SYSTEM (prompts.py:179-217) | ENRICH_SYSTEM (prompts.py:219-266) | Gap? |
+|---------------------|-----------------------------------|-------------------------------------|------|
+| HGNC search by symbol | `query_lifesciences(query="ACVR1", tool_name="hgnc_search_genes")` | — | Aligned, but syntax differs (curl vs MCP wrapper) |
+| HGNC fetch by ID | — | `query_lifesciences(tool_name="hgnc_get_gene", tool_args={"hgnc_id": "HGNC:171"})` | Aligned |
+| Ensembl lookup | Curl: `rest.ensembl.org/lookup/id/` | Not in prompts — uses `ensembl_get_gene` MCP | **GAP**: Skill uses curl, production uses MCP |
+| Ensembl VEP | Curl: `rest.ensembl.org/vep/` | Not in any production prompt | **GAP**: VEP not used in production |
+| NCBI E-utilities | Curl: `eutils.ncbi.nlm.nih.gov/` | `query_lifesciences(tool_name="entrez_search_genes")` in production | Partially aligned — different access method |
+| Cross-references | Curl: `rest.ensembl.org/xrefs/id/` | Mentioned in VALIDATE_SYSTEM but not ENRICH | **GAP**: Useful for ENRICH, only documented for VALIDATE |
+
+**Key gaps**:
+1. Skill uses raw curl; production uses MCP wrappers — different invocation patterns
+2. VEP variant annotation is in the skill but not in any production phase
+3. Ensembl cross-references are useful for ENRICH but only documented in VALIDATE
+
+### Proteomics Skill ↔ EXPAND Prompt
+
+| Proteomics Skill Step | EXPAND_SYSTEM (prompts.py:268-314) | Gap? |
+|----------------------|-------------------------------------|------|
+| UniProt search | Not in EXPAND — belongs in ENRICH | **MISALIGNED**: Skill covers both ENRICH and EXPAND scope |
+| UniProt get protein | Not in EXPAND — belongs in ENRICH | Same |
+| UniProt batch ID mapping | Not in any production prompt | **GAP**: Not used in production |
+| STRING network | `query_lifesciences(tool_name="string_search_proteins")` + `string_get_interactions` | Aligned |
+| STRING enrichment | Curl: `string-db.org/api/json/enrichment` | Not in production prompts | **GAP**: Functional enrichment not used |
+| BioGRID interactions | `query_lifesciences(tool_name="biogrid_get_interactions")` | Aligned |
+
+**Key gaps**:
+1. Proteomics skill spans both ENRICH and EXPAND phases — doesn't map cleanly
+2. STRING functional enrichment is in the skill but not used in production
+3. UniProt batch ID mapping is in the skill but not used in production
+
+### Pharmacology Skill ↔ TRAVERSE_DRUGS Prompt
+
+| Pharmacology Skill Step | TRAVERSE_DRUGS_SYSTEM (prompts.py:316-360) | Gap? |
+|------------------------|---------------------------------------------|------|
+| ChEMBL compound search | `query_lifesciences(tool_name="chembl_search_compounds")` | Aligned |
+| ChEMBL mechanism | Curl: `/mechanism?molecule_chembl_id=...` | Not in prompts — production uses Open Targets instead | **GAP**: Skill emphasizes ChEMBL mechanisms; production prefers Open Targets |
+| ChEMBL drug indication | Curl: `/drug_indication?...` | Not in prompts | **GAP**: Not in production |
+| ChEMBL bioactivity | Curl: `/activity?...` | Not in prompts | **GAP**: Not in production |
+| Open Targets fallback | Not in skill | `query_api_direct(url="opentargets.org/graphql")` | **CRITICAL GAP**: Skill omits the Open Targets fallback that production relies on |
+| PubChem | Curl: `pubchem.ncbi.nlm.nih.gov/rest/pug/` | Not in production | **GAP**: PubChem not used in production |
+| IUPHAR/GtoPdb | Curl: `guidetopharmacology.org/services/` | Not in production | **GAP**: IUPHAR not used in production |
+
+**Key gaps**:
+1. **CRITICAL**: Pharmacology skill has NO Open Targets fallback — this is the primary drug discovery mechanism in production
+2. Skill emphasizes ChEMBL endpoints that frequently fail (500 errors)
+3. PubChem and IUPHAR are documented but not used in production
+
+### Clinical Skill ↔ TRAVERSE_TRIALS + VALIDATE Prompts
+
+| Clinical Skill Step | TRAVERSE_TRIALS/VALIDATE (prompts.py:362-456) | Gap? |
+|--------------------|------------------------------------------------|------|
+| Open Targets target-disease | Not in TRAVERSE_TRIALS prompt (used in EXPAND) | **MISALIGNED**: Skill puts this in clinical; production puts it in EXPAND |
+| Open Targets knownDrugs | Referenced in TRAVERSE_DRUGS prompt | **MISALIGNED**: Skill puts in clinical; production in drugs |
+| ClinicalTrials.gov search | `query_lifesciences(tool_name="clinicaltrials_search_trials")` | Aligned |
+| ClinicalTrials.gov details | `query_lifesciences(tool_name="clinicaltrials_get_trial")` | Aligned |
+| Trial verification | VALIDATE_SYSTEM verifies NCT IDs | Aligned |
+
+**Key gaps**:
+1. Open Targets is split between clinical skill and drugs/expand in production — confusing mapping
+2. Clinical skill's `filter.advanced=AREA[Phase]PHASE3` (line 121) — not well-tested; may not work reliably
+
+### Graph-Builder Skill ↔ Supervisor + All Specialists
+
+| Graph-Builder Feature | lifesciences.py | Gap? |
+|----------------------|-----------------|------|
+| 7-phase protocol | 7 specialists in `subagents` list | Aligned (skill says 7 phases, code has 7) |
+| Tier 1: MCP Tools | `query_lifesciences` wrapper | Aligned conceptually, different syntax |
+| Tier 2: Curl Commands | `query_api_direct` for direct HTTP | **GAP**: Skill lists curl commands; production wraps in `query_api_direct` |
+| Tier 3: Graphiti | `persist_to_graphiti` | **BUG**: Imported but not wired to persistence_specialist (tools=[]) |
+| Parallel Phase 4a/4b | Supervisor prompt allows it (line 54-57) | Aligned in design; observed to run sequentially |
+| Data passing | Supervisor prompt mentions CURIEs | **GAP**: Skill doesn't address inter-phase data passing |
+| Error recovery | Not in skill | Not in supervisor prompt | **GAP**: Missing in both |
+
+---
+
+## 3. CURIE Format Discrepancies
+
+| Entity Type | Skill (graph-builder) | prompts.py | mcp.py Docstring | Consistent? |
+|-------------|----------------------|------------|------------------|-------------|
+| Gene (HGNC) | `HGNC:11998` | `HGNC:171` | `"HGNC:..."` | YES — all use HGNC: prefix |
+| Protein (UniProt) | `UniProtKB:P04637` | `"Q04771"` (bare) | `"P12345"` (bare) | **NO** — skill uses CURIE, production uses bare |
+| Compound (ChEMBL) | `CHEMBL:3137309` | `"CHEMBL25"` (bare) | `"CHEMBL..."` (bare) | **NO** — skill adds colon separator, production doesn't |
+| STRING protein | `STRING:9606.ENSP00000269305` AND `9606.ENSP00000269305` | `"9606.ENSP00000263640"` (bare) | Unspecified | **NO** — skill self-contradicts, production uses bare |
+| Disease (EFO) | `EFO_0000574` | Not specified | Not in mcp.py | INDETERMINATE |
+| Disease (MONDO) | `MONDO_0018875` | `MONDO:0018875` | Not in mcp.py | **NO** — underscore vs colon |
+| Trial (NCT) | `NCT:00461032` | `"NCT03312634"` (bare) | Not in mcp.py | **NO** — skill uses CURIE, production uses bare |
+| Pathway (WikiPathways) | `WP:WP1742` | Not specified | Not in mcp.py | INDETERMINATE |
+| Ensembl gene | `ENSG00000141510` (bare) | `"ENSG00000115170"` (bare) | `"ENSG..."` (bare) | YES — all use bare |
+
+**Root cause**: The skill tries to use W3C CURIE syntax (`PREFIX:LOCAL_ID`) for graph node IDs, but the production code passes bare IDs to MCP tools (which is what the FastMCP server expects). These are two different contexts:
+1. **API arguments**: Bare IDs (what the MCP server accepts)
+2. **Graph node IDs**: Full CURIEs (for Graphiti persistence)
+
+Neither the skill nor production clearly documents this distinction.
+
+---
+
+## 4. Missing Fallback Patterns
+
+### Documented in Production but Missing from Skills
+
+| Fallback | Production Location | Which Skill Should Document It |
+|----------|--------------------|---------------------------------|
+| ChEMBL → Open Targets `knownDrugs` | `TRAVERSE_DRUGS_SYSTEM` (prompts.py:325-329) | pharmacology, graph-builder |
+| Multiple search attempts (max 3) | `ANCHOR_SYSTEM` (prompts.py:197) | genomics (no retry guidance) |
+| Report "Unresolved" for failed resolution | `ANCHOR_SYSTEM` (prompts.py:197) | All skills (none say to report failure) |
+
+### Missing from Both Skills and Production
+
+| Fallback | Why Needed | Recommendation |
+|----------|-----------|----------------|
+| STRING → BioGRID | When STRING returns <3 interactions | Add to proteomics and graph-builder |
+| UniProt → Ensembl xrefs | When UniProt is down | Add to proteomics |
+| WikiPathways → STRING enrichment | When WikiPathways has no results for gene | Add to graph-builder |
+| Disease-only trial search | When drug-specific search returns zero trials | Add to clinical and graph-builder |
+
+---
+
+## 5. Missing Error Recovery Guidance
+
+### Production Supervisor (lifesciences.py:68-69)
+```
+- Do not skip phases. If a phase returns no results, note this and continue.
+```
+
+This is the **only** error recovery guidance. Missing:
+- What to do when ENRICH fails to return Ensembl ID (needed by TRAVERSE_DRUGS)
+- What to do when TRAVERSE_DRUGS returns agonists for gain-of-function diseases
+- What to do when 3+ phases return no results
+- Circuit breaker: when to stop and return partial results
+
+### Skills
+None of the 6 skills have any error recovery guidance.
+
+---
+
+## 6. Rate Limit Discrepancies
+
+| API | Skill Documentation | Production (mcp.py) | Match? |
+|-----|--------------------|-----------------------|--------|
+| HGNC | 10 req/s (genomics:114) | Not rate-limited in mcp.py | MISMATCH — skill overstates restriction |
+| Ensembl | 15 req/s (genomics:115) | Not in mcp.py | N/A — skill uses curl directly |
+| NCBI | 3 req/s, 10 with key (genomics:116) | Not in mcp.py | N/A — skill uses curl directly |
+| UniProt | 100 req/s (proteomics:127) | Not rate-limited in mcp.py | MISMATCH |
+| STRING | 1 req/s (proteomics:128) | 1 req/s (mcp.py rate limiter) | MATCH |
+| BioGRID | 10 req/s (proteomics:129) | 0.5s delay (mcp.py rate limiter) | APPROXIMATE MATCH |
+| ChEMBL | 100 req/s (pharmacology:169) | 0.5s delay (mcp.py rate limiter) | MISMATCH — skill says 100/s; production throttles to 2/s |
+| PubChem | 5 req/s (pharmacology:170) | Not in mcp.py | N/A |
+| Open Targets | 100 req/s (clinical:199) | 0.2s delay (mcp.py rate limiter) | APPROXIMATE MATCH |
+| ClinicalTrials.gov | "Varies" (clinical:200) | Not rate-limited in mcp.py | MISMATCH |
+
+**Key issue**: ChEMBL is rate-limited to ~2 req/s in production but skill says 100 req/s. This mismatch could cause confusion when multiple rapid calls time out.
+
+---
+
+## 7. Alignment Matrix Summary
+
+| Dimension | Alignment Score (0-4) | Notes |
+|-----------|----------------------|-------|
+| Phase naming | 4 | Near-perfect match |
+| Tool invocation syntax | 1 | Skills use dot notation / curl; production uses `query_lifesciences()` wrapper |
+| CURIE format | 1 | Systematic disagreement on 5 of 9 entity types |
+| Workflow steps | 2 | Phase mapping exists but skills span multiple production phases |
+| Fallback patterns | 1 | Critical Open Targets fallback missing from skills |
+| Error recovery | 0 | Absent from both (minimal in production supervisor) |
+| Rate limits | 2 | Some match, some significantly different |
+| Tool assignment | 3 | Production has correct tools per specialist; skill doesn't specify |
+
+**Overall alignment**: 14/32 (44%) — Significant gaps that explain the behavioral failures documented in the retrospective.
+
+---
+
+## 8. Recommendations
+
+### Priority 1: Fix Critical Misalignments
+
+1. **Add Open Targets fallback to pharmacology skill** — this is the #1 missing pattern
+2. **Standardize CURIE format** with explicit two-context rule (API args vs graph node IDs)
+3. **Align tool invocation syntax** — skills should show `query_lifesciences()` calls, not just curl
+
+### Priority 2: Add Missing Patterns
+
+4. **Add error recovery guidance** to graph-builder skill
+5. **Add disease-only trial search fallback** to clinical skill
+6. **Add mechanism filtering** (agonist vs antagonist) for gain-of-function diseases
+7. **Fix ChEMBL rate limit** documentation to match production (2 req/s, not 100 req/s)
+
+### Priority 3: Structural Improvements
+
+8. **Convert reference cards to workflows** with mandatory LOCATE→RETRIEVE steps
+9. **Add external knowledge restriction** per Anthropic hallucination guidance
+10. **Clarify skill ↔ production phase mapping** in graph-builder skill

--- a/docs/evaluations/skills-evaluation-report.md
+++ b/docs/evaluations/skills-evaluation-report.md
@@ -1,0 +1,256 @@
+# Life Sciences Skills — Evaluation Report
+
+**Date**: 2026-02-07
+**Scope**: All 6 `.claude/skills/lifesciences-*` skill definitions
+**Baseline**: ACVR1/FOP retrospective + production code analysis
+
+---
+
+## 1. Executive Summary
+
+The life sciences Claude Code skills underwent a comprehensive 3-agent evaluation:
+1. **Behavioral Audit** analyzed what Claude actually does vs what skills instruct
+2. **Consistency Analysis** compared skills against the production `apps/api/` implementation
+3. **Skills Rewrite** applied findings to improve all 6 skills
+
+**Core finding**: Claude Code frequently ignores the directive to use MCP tools for entity resolution, instead answering from parametric knowledge. This leads to hallucinated entities, inconsistent CURIEs, and ungrounded claims. The root cause is that skills were structured as **reference cards** (API endpoint catalogs) rather than **enforced workflows** with mandatory tool-use gates.
+
+**Changes made**: All 6 skills were rewritten to enforce a disciplined LOCATE → RETRIEVE pattern with explicit grounding rules, aligned with Anthropic's official guidance on hallucination reduction, skill authoring, and tool use.
+
+---
+
+## 2. Behavioral Audit Results
+
+### Key Findings
+
+**Pattern 1 — Parametric Knowledge Override**: All 6 skills were vulnerable to Claude answering from training knowledge instead of calling tools. The skills provided curl examples but never said "you MUST call this before answering."
+
+**Pattern 2 — Reference Card vs Workflow**: 4 of 6 skills (genomics, proteomics, pharmacology, clinical) were structured as reference cards with no workflow enforcement. Only CRISPR had a strong 5-phase pipeline.
+
+**Pattern 3 — CURIE Inconsistency**: No skill produced consistent CURIEs. Formats varied between bare IDs and full CURIEs within the same document.
+
+### Hallucination Risk Before Changes
+
+| Skill | Risk Level | Reason |
+|-------|------------|--------|
+| genomics | HIGH | All facts available in parametric knowledge |
+| proteomics | HIGH | Common proteins well-known |
+| pharmacology | HIGH | Drug names/mechanisms widely known |
+| clinical | MEDIUM | GraphQL requires specific IDs (forces some tool use) |
+| crispr | LOW | ORCS data is obscure enough to force API calls |
+| graph-builder | HIGH | Amplifies upstream hallucination risks |
+
+### ACVR1/FOP Trace Analysis (Observed Failures)
+
+| Phase | Expected | Observed | Root Cause |
+|-------|----------|----------|------------|
+| ANCHOR | HGNC LOCATE → RETRIEVE | Partial — over-resolved drugs | No scope boundaries |
+| ENRICH | UniProt RETRIEVE | Used PubMed narrative instead | No mandatory tool-use gate |
+| EXPAND | STRING RETRIEVE | Incomplete — missed pathway components | No RETRIEVE verification |
+| DRUGS | Open Targets LOCATE | Returned agonists (wrong drugs for FOP) | No mechanism filter |
+| TRIALS | ClinicalTrials.gov LOCATE | Searched wrong drugs → zero results | Cascading from DRUGS |
+| VALIDATE | NCT ID RETRIEVE | Hallucinated NCT ID from prompt example | No grounding enforcement |
+| PERSIST | Graphiti add_memory | Failed — tools=[] | Production bug (unrelated) |
+
+Full audit: `docs/evaluations/behavioral-audit.md`
+
+---
+
+## 3. Consistency Analysis Results
+
+### Skills ↔ Production Alignment (Before Changes)
+
+| Dimension | Score (0-4) | Notes |
+|-----------|------------|-------|
+| Phase naming | 4 | Near-perfect match |
+| Tool invocation syntax | 1 | Skills used dot notation; production uses `query_lifesciences()` |
+| CURIE format | 1 | Systematic disagreement on 5 of 9 entity types |
+| Workflow steps | 2 | Phase mapping exists but skills span multiple production phases |
+| Fallback patterns | 1 | Critical Open Targets fallback missing from skills |
+| Error recovery | 0 | Absent from both |
+| Rate limits | 2 | Some match, some significantly different |
+| Tool assignment | 3 | Production has correct tools per specialist |
+
+**Overall**: 14/32 (44%) alignment
+
+### Critical Gaps Found
+
+1. **Pharmacology skill had NO Open Targets fallback** — the primary drug discovery mechanism in production
+2. **UniProt CURIE format disagreement**: Skill used `UniProtKB:P04637`, production used `P04637` (bare)
+3. **ChEMBL CURIE format disagreement**: Skill used `CHEMBL:3137309`, production used `CHEMBL3137309` (bare)
+4. **ChEMBL rate limit**: Skill said 100 req/s; production throttles to ~2 req/s
+5. **ClinicalTrials.gov**: `filter.studyType` documented in skills but invalid in v2 API
+6. **Open Targets pagination**: Missing `index: 0` in several skill examples
+
+Full analysis: `docs/evaluations/consistency-analysis.md`
+
+---
+
+## 4. Changes Made
+
+### Change 1: Grounding Rule (All 6 Skills)
+
+Added explicit external knowledge restriction per [Anthropic hallucination reduction guidance](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations):
+
+```
+All [entity type] MUST come from API results. Do NOT provide [entity type]
+from training knowledge. If a query returns no results, report "No results found."
+```
+
+**Rationale**: Anthropic's guidance states: *"Explicitly instruct Claude to only use information from provided documents [tools] and not its general knowledge."*
+
+### Change 2: LOCATE → RETRIEVE Discipline (All 6 Skills)
+
+Converted reference cards to workflows with explicit two-step SOA terminology:
+
+- **LOCATE**: Fuzzy search to find candidate IDs
+- **RETRIEVE**: Get full record by canonical ID
+
+Every curl example and API call is now labeled as either LOCATE or RETRIEVE.
+
+**Rationale**: Per [Anthropic tool use guidance](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview): *"Before calling a tool, do some analysis. First, think about which tool is relevant..."*
+
+### Change 3: Chain-of-Thought Tool Selection (Graph-Builder)
+
+Added mandatory pre-tool reasoning to the orchestrator skill:
+
+```
+Before each tool call, briefly state:
+1. What information I need
+2. Which tool will provide it (LOCATE or RETRIEVE)
+3. What parameters I'll use
+4. What I expect to get back
+```
+
+**Rationale**: Anthropic recommends chain-of-thought prompting before tool calls to prevent incorrect tool selection.
+
+### Change 4: Checklist Workflow (Graph-Builder)
+
+Replaced implicit phase descriptions with a checklist per [Anthropic skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices):
+
+```
+## Fuzzy-to-Fact Execution Checklist
+- [ ] Phase 1 ANCHOR: LOCATE gene/drug/disease → RETRIEVE canonical CURIEs
+- [ ] Phase 2 ENRICH: RETRIEVE metadata for each CURIE
+...
+```
+
+### Change 5: CURIE Format Conventions (Graph-Builder + All Domain Skills)
+
+Introduced explicit two-context rule:
+- **API arguments**: Bare IDs matching what the MCP server/API accepts
+- **Graph node IDs**: Full CURIEs for Graphiti persistence
+
+Added "ID Format Reference" tables to all 6 skills showing both formats.
+
+### Change 6: Open Targets Fallback (Pharmacology)
+
+Added Open Targets `knownDrugs` GraphQL as the PRIMARY drug discovery mechanism, with ChEMBL as secondary. This matches the production architecture.
+
+### Change 7: API Reliability & Fallback Tables (Graph-Builder, Pharmacology)
+
+Added explicit fallback patterns:
+| Primary | Fallback | When |
+|---------|----------|------|
+| ChEMBL detail | Open Targets `knownDrugs` | On 500 error |
+| STRING network | BioGRID interactions | <3 interactions |
+| Drug+disease trial search | Disease-only search | Zero results |
+
+### Change 8: ClinicalTrials.gov v2 Fixes (Clinical)
+
+- Documented that `filter.studyType` is NOT valid in v2 API
+- Added correct syntax: `query.term=AREA[StudyType]INTERVENTIONAL`
+- Added valid parameters table
+
+### Change 9: Gain-of-Function Disease Filter (Graph-Builder, Pharmacology)
+
+Added mechanism filtering guidance for diseases caused by protein overactivation:
+- INCLUDE: inhibitors, antagonists, negative modulators
+- EXCLUDE: agonists, positive modulators, activators
+
+This directly addresses the ACVR1/FOP failure where agonists were returned.
+
+---
+
+## 5. Before/After Comparison
+
+### Graph-Builder SKILL.md
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Grounding rule | None | Explicit external knowledge restriction |
+| LOCATE→RETRIEVE | Implicit (code comments) | Explicit two-step discipline with labels |
+| Chain-of-thought | None | Mandatory pre-tool reasoning |
+| Workflow structure | Phase descriptions | Checklist with checkboxes |
+| CURIE format | Defined but contradictory | Two-context rule (API args vs graph IDs) |
+| Fallback patterns | Open Targets mentioned | Formal fallback table |
+| Mechanism filtering | None | Gain-of-function disease filter |
+| Tool invocation syntax | Dot notation (`hgnc.search_genes`) | `query_lifesciences()` wrapper syntax |
+
+### Domain Skills (Genomics, Proteomics, Pharmacology, Clinical, CRISPR)
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Structure | Reference card | Workflow with LOCATE/RETRIEVE labels |
+| Grounding rule | None | Per-skill external knowledge restriction |
+| ID format documentation | Inconsistent/missing | ID Format Reference tables |
+| Fallback patterns | None | Explicit fallback tables (where applicable) |
+| Rate limits | Some incorrect | Aligned with production |
+| ClinicalTrials.gov filters | Included invalid params | Fixed with valid v2 parameters |
+
+---
+
+## 6. Estimated Improvement (ACVR1/FOP Regression Test)
+
+Based on the changes, here's how the ACVR1/FOP test case would likely score:
+
+| Phase | Before Score | After Score (Expected) | Key Change |
+|-------|-------------|------------------------|------------|
+| ANCHOR | 2/4 | 3/4 | Grounding rule prevents scope creep |
+| ENRICH | 1/4 | 3/4 | Mandatory RETRIEVE steps for structured metadata |
+| EXPAND | 2/4 | 3/4 | RETRIEVE labels for pathway components |
+| DRUGS | 0/4 | 3/4 | Mechanism filter + Open Targets as primary |
+| TRIALS | 0/4 | 2/4 | Disease-only fallback search |
+| VALIDATE | 0/4 | 3/4 | Grounding rule prevents hallucination injection |
+| PERSIST | 0/4 | N/A | Requires production bug fix (tools=[]) |
+| **Total** | **5/24** | **17/24** | **+12 points** |
+
+---
+
+## 7. Remaining Gaps & Next Steps
+
+### Not Addressed in This Round
+
+1. **Production code changes**: The `persist_to_graphiti` bug (`lifesciences.py:132, tools=[]`) requires a production code fix, not a skill change
+2. **Multishot examples**: Anthropic recommends 3-5 worked examples per prompt; skills currently have 0-1. Adding these would further improve tool-use compliance
+3. **Formal JSON schemas**: `<output_format>` sections in production prompts use informal JSON; formal schemas would improve output compliance
+4. **Error recovery in production supervisor**: The supervisor prompt (`lifesciences.py:45-77`) still lacks error recovery routing
+5. **Inter-phase data passing**: Production supervisor still relies on the LLM to relay CURIEs between phases; filesystem-based passing would be more reliable
+
+### Recommended Next Steps
+
+1. **Fix production bug**: `lifesciences.py:132` → `"tools": [persist_to_graphiti]`
+2. **Add multishot examples** to all specialist prompts in `prompts.py`
+3. **Run all 3 test cases** from `docs/evaluations/test-protocol.md` and record scores
+4. **Add error recovery** to supervisor prompt for cascading failures
+5. **Consider filesystem-based data passing** for inter-phase CURIEs
+
+---
+
+## 8. Sources
+
+### Anthropic Official Documentation
+- [Reduce Hallucinations](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations) — "Explicitly instruct Claude to only use information from provided documents and not its general knowledge"
+- [Skill Authoring Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) — Workflow checklists, feedback loops, consistent terminology, progressive disclosure, keep SKILL.md under 500 lines
+- [Tool Use with Claude](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) — Chain-of-thought tool selection, tool_choice parameter
+- [Multishot Prompting](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/multishot-prompting) — "3-5 diverse examples = better performance"
+
+### Project Documentation
+- ACVR1/FOP Retrospective: `docs/retrospectives/acvr1-fop-fuzzy-to-fact-retrospective.md`
+- Prior Art Patterns: `reference/prior-art-api-patterns.md` (BTE-RAG, TRAPI, W3C CURIE Syntax)
+- Production Code: `apps/api/shared/prompts.py`, `apps/api/graphs/lifesciences.py`
+
+### Evaluation Artifacts
+- Test Protocol: `docs/evaluations/test-protocol.md`
+- Behavioral Audit: `docs/evaluations/behavioral-audit.md`
+- Consistency Analysis: `docs/evaluations/consistency-analysis.md`

--- a/docs/evaluations/test-protocol.md
+++ b/docs/evaluations/test-protocol.md
@@ -1,0 +1,192 @@
+# Life Sciences Skills — Evaluation Test Protocol
+
+## Purpose
+
+This document defines 3 standardized test cases with gold-standard expected outputs for evaluating the life sciences Claude Code skills. Each test case specifies the expected LOCATE (fuzzy search) and RETRIEVE (get-by-ID) tool calls, expected CURIEs, and gold-standard drugs/trials.
+
+## Test Methodology
+
+For each test case, the evaluator should:
+1. Invoke the `lifesciences-graph-builder` skill with the input query
+2. Record every tool call made (MCP or curl)
+3. Check whether LOCATE preceded RETRIEVE for each entity
+4. Verify output contains canonical CURIEs (not just names)
+5. Compare drugs/trials found against gold standard
+6. Note any facts from parametric knowledge (not grounded in tool results)
+
+---
+
+## Test Case 1: TP53 Pathway (Well-Studied Target)
+
+### Input Query
+> "What drugs target TP53 and its interactors in cancer?"
+
+### Expected LOCATE Calls (Fuzzy Search)
+
+| Step | Tool | Call | Expected Result |
+|------|------|------|-----------------|
+| 1.1 | `query_lifesciences` | `tool_name="hgnc_search_genes"`, `query="TP53"` | HGNC:11998 |
+| 1.2 | `query_lifesciences` | `tool_name="string_search_proteins"`, `query="TP53"` | 9606.ENSP00000269305 |
+| 1.3 | `query_lifesciences` | `tool_name="chembl_search_compounds"`, `query="Venetoclax"` | CHEMBL3137309 |
+
+### Expected RETRIEVE Calls (Get-by-ID)
+
+| Step | Tool | Call | Expected Output |
+|------|------|------|-----------------|
+| 2.1 | `query_lifesciences` | `tool_name="hgnc_get_gene"`, `tool_args={"hgnc_id": "HGNC:11998"}` | Symbol: TP53, UniProt: P04637, Ensembl: ENSG00000141510 |
+| 2.2 | `query_lifesciences` | `tool_name="uniprot_get_protein"`, `tool_args={"uniprot_id": "P04637"}` | Function text mentioning BAX, BCL2, FAS |
+| 2.3 | `query_lifesciences` | `tool_name="string_get_interactions"`, `tool_args={"string_id": "9606.ENSP00000269305"}` | MDM2 (0.999), SIRT1, ATM, BCL2 |
+| 2.4 | Open Targets GraphQL | `target(ensemblId: "ENSG00000171791") { knownDrugs }` | Venetoclax, Navitoclax |
+
+### Expected CURIEs in Output
+
+| Entity | CURIE | Type |
+|--------|-------|------|
+| TP53 | HGNC:11998 | Gene |
+| BCL2 | HGNC:990 | Gene |
+| p53 protein | UniProtKB:P04637 | Protein |
+| Venetoclax | CHEMBL:3137309 | Compound |
+
+### Gold-Standard Drugs
+
+| Drug | Phase | Mechanism | Target |
+|------|-------|-----------|--------|
+| Venetoclax | 4 (approved) | BCL2 inhibitor | BCL2 |
+| Navitoclax | 3 | BCL2/BCL-XL inhibitor | BCL2, BCL2L1 |
+| APR-246 (Eprenetapopt) | 3 | p53 reactivator | TP53 |
+| Idasanutlin | 3 | MDM2 antagonist | MDM2 |
+
+### Gold-Standard Trials
+
+| NCT ID | Drug | Phase | Status |
+|--------|------|-------|--------|
+| NCT00461032 | Venetoclax (ABT-263 predecessor study) | Phase 1 | Completed |
+| NCT02993523 | Venetoclax + rituximab | Phase 3 | Completed |
+
+---
+
+## Test Case 2: ACVR1/FOP (From Retrospective)
+
+### Input Query
+> "What drugs target the ACVR1 pathway in FOP?"
+
+### Expected LOCATE Calls
+
+| Step | Tool | Call | Expected Result |
+|------|------|------|-----------------|
+| 1.1 | `query_lifesciences` | `tool_name="hgnc_search_genes"`, `query="ACVR1"` | HGNC:171 |
+| 1.2 | `query_lifesciences` | `tool_name="clinicaltrials_search_trials"`, `query="fibrodysplasia ossificans progressiva"` | Multiple FOP trials |
+
+### Expected RETRIEVE Calls
+
+| Step | Tool | Call | Expected Output |
+|------|------|------|-----------------|
+| 2.1 | `query_lifesciences` | `tool_name="hgnc_get_gene"`, `tool_args={"hgnc_id": "HGNC:171"}` | UniProt: Q04771, Ensembl: ENSG00000115170 |
+| 2.2 | `query_lifesciences` | `tool_name="uniprot_get_protein"`, `tool_args={"uniprot_id": "Q04771"}` | BMP type I receptor serine/threonine kinase |
+| 2.3 | Open Targets GraphQL | `target(ensemblId: "ENSG00000115170") { knownDrugs }` | Palovarotene, Garetosmab (must be inhibitors/antagonists) |
+| 2.4 | `query_lifesciences` | `tool_name="clinicaltrials_get_trial"`, `tool_args={"nct_id": "NCT03312634"}` | Palovarotene Phase 3 trial |
+
+### Expected CURIEs in Output
+
+| Entity | CURIE | Type |
+|--------|-------|------|
+| ACVR1 | HGNC:171 | Gene |
+| Activin receptor type-1 | UniProtKB:Q04771 | Protein |
+| FOP | MONDO:0018875 | Disease |
+
+### Gold-Standard Drugs
+
+| Drug | Phase | Mechanism | Critical Note |
+|------|-------|-----------|---------------|
+| Palovarotene | 4 (approved) | RARgamma agonist (downstream inhibition of BMP) | FDA-approved for FOP |
+| Garetosmab | 2/3 | Anti-Activin A antibody | Upstream pathway blockade |
+| LDN-193189 | Preclinical | ACVR1 kinase inhibitor | Direct target inhibitor |
+
+### Critical Anti-Pattern
+MUST NOT return: Eptotermin Alfa, Dibotermin Alfa (these are BMP AGONISTS that would worsen FOP). The TRAVERSE_DRUGS phase must filter for inhibitors/antagonists for gain-of-function diseases.
+
+### Gold-Standard Trials
+
+| NCT ID | Drug | Phase | Status |
+|--------|------|-------|--------|
+| NCT03312634 | Palovarotene | Phase 3 | Completed |
+| NCT02190747 | Palovarotene | Phase 2 | Completed |
+| NCT05394116 | Garetosmab | Phase 2/3 | Recruiting |
+
+---
+
+## Test Case 3: BRCA1 Breast Cancer (Common Query)
+
+### Input Query
+> "What PARP inhibitors are used for BRCA1-mutant breast cancer?"
+
+### Expected LOCATE Calls
+
+| Step | Tool | Call | Expected Result |
+|------|------|------|-----------------|
+| 1.1 | `query_lifesciences` | `tool_name="hgnc_search_genes"`, `query="BRCA1"` | HGNC:1100 |
+| 1.2 | `query_lifesciences` | `tool_name="chembl_search_compounds"`, `query="Olaparib"` | CHEMBL1336 |
+
+### Expected RETRIEVE Calls
+
+| Step | Tool | Call | Expected Output |
+|------|------|------|-----------------|
+| 2.1 | `query_lifesciences` | `tool_name="hgnc_get_gene"`, `tool_args={"hgnc_id": "HGNC:1100"}` | UniProt: P38398, Ensembl: ENSG00000012048 |
+| 2.2 | `query_lifesciences` | `tool_name="uniprot_get_protein"`, `tool_args={"uniprot_id": "P38398"}` | DNA repair, tumor suppressor |
+| 2.3 | Open Targets GraphQL | `target(ensemblId: "ENSG00000012048") { knownDrugs }` | PARP inhibitors |
+| 2.4 | ClinicalTrials.gov | `query.intr=olaparib&query.cond=breast+cancer` | Multiple trials |
+
+### Expected CURIEs in Output
+
+| Entity | CURIE | Type |
+|--------|-------|------|
+| BRCA1 | HGNC:1100 | Gene |
+| BRCA1 protein | UniProtKB:P38398 | Protein |
+| Breast cancer | EFO:0000305 | Disease |
+| Olaparib | CHEMBL:1336 | Compound |
+
+### Gold-Standard Drugs
+
+| Drug | Phase | Mechanism | Approval |
+|------|-------|-----------|----------|
+| Olaparib | 4 (approved) | PARP1/2 inhibitor | FDA-approved for BRCA-mutant breast cancer |
+| Talazoparib | 4 (approved) | PARP1/2 inhibitor | FDA-approved for BRCA-mutant breast cancer |
+| Niraparib | 4 (approved) | PARP1/2 inhibitor | FDA-approved for ovarian, expanding to breast |
+| Rucaparib | 4 (approved) | PARP1/2/3 inhibitor | FDA-approved for BRCA-mutant ovarian |
+
+### Gold-Standard Trials
+
+| NCT ID | Drug | Phase | Status |
+|--------|------|-------|--------|
+| NCT02000622 | Olaparib (OlympiAD) | Phase 3 | Completed |
+| NCT01945775 | Talazoparib (EMBRACA) | Phase 3 | Completed |
+
+---
+
+## Scoring Rubric
+
+### Per-Skill Scoring (0–4 points per criterion)
+
+| Criterion | 0 | 1 | 2 | 3 | 4 |
+|-----------|---|---|---|---|---|
+| **Tool Usage** | No tools used | Some tools, no pattern | LOCATE used but no RETRIEVE | LOCATE→RETRIEVE for most entities | LOCATE→RETRIEVE for ALL entities |
+| **Grounding** | All from parametric knowledge | Mostly parametric with some tools | Mixed — some grounded, some not | Mostly grounded with minor gaps | Fully grounded — every claim from tool results |
+| **CURIEs** | No CURIEs in output | Some entity names only | Some CURIEs, inconsistent format | CURIEs for most entities, consistent format | All entities have CURIEs, format matches convention |
+| **Drug Accuracy** | No drugs found or all wrong | 1 correct drug | 2 correct drugs | 3+ correct drugs, no harmful errors | All gold-standard drugs found, no inappropriate results |
+| **Trial Accuracy** | No trials or hallucinated NCTs | 1 verified trial | 2+ verified trials | All trials verified, correct phases | Gold-standard trials found and verified |
+
+### Overall Score
+
+- **0–4**: Skill needs fundamental redesign
+- **5–9**: Significant gaps — LOCATE→RETRIEVE discipline missing
+- **10–14**: Functional but inconsistent — needs enforcement
+- **15–17**: Good — minor gaps in coverage
+- **18–20**: Excellent — fully grounded, accurate results
+
+---
+
+## Evaluation Cadence
+
+- Run all 3 test cases after any SKILL.md modification
+- Record results in `docs/evaluations/behavioral-audit.md`
+- Compare against previous scores to detect regressions


### PR DESCRIPTION
## Summary

- Add `lifesciences-research` MCP server to `.mcp.json` for direct access to 34 tools across 12 databases (HGNC, UniProt, STRING, ChEMBL, Open Targets, ClinicalTrials.gov, PubChem, IUPHAR, BioGRID, Ensembl, Entrez, WikiPathways)
- Rewrite all 6 lifesciences skills: MCP tools are now PRIMARY, curl is FALLBACK
- Add LOCATE→RETRIEVE discipline and grounding rules to prevent hallucinated entity names and IDs
- Add gain-of-function disease filter to graph-builder and pharmacology skills
- Add evaluation documents: test protocol (3 gold-standard test cases), behavioral audit, consistency analysis, evaluation report

## Verified

ACVR1/FOP end-to-end test passed in new session:
- All MCP tools called successfully (hgnc, uniprot, opentargets, string, chembl, pubchem, iuphar, clinicaltrials)
- LOCATE→RETRIEVE discipline followed throughout
- Gain-of-function filter correctly excluded 2 agonists (Eptotermin Alfa, Dibotermin Alfa)
- 7 drug candidates found across 4 mechanism classes
- All 7 NCT IDs validated

## Test plan

- [ ] Start new Claude Code session (MCP servers require session restart)
- [ ] Run `ToolSearch` for `hgnc_search_genes` to confirm MCP tools load
- [ ] Run `/lifesciences-graph-builder "What drugs target the ACVR1 pathway in FOP?"` and verify MCP tools used (not curl)
- [ ] Verify agonists excluded, inhibitors found, NCT IDs validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)