### PR TITLE
Fix disease CURIE resolution and Open Targets pagination in skills

### DIFF
--- a/.claude/skills/lifesciences-pharmacology/SKILL.md
+++ b/.claude/skills/lifesciences-pharmacology/SKILL.md
@@ -57,8 +57,14 @@ FALLBACK (curl):
 ```bash
 curl -s -X POST "https://api.platform.opentargets.org/api/v4/graphql" \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { knownDrugs(page: {index: 0, size: 10}) { rows { drug { name id } mechanismOfAction phase } } } }"}'
+  -d '{"query": "{ target(ensemblId: \"ENSG00000171791\") { knownDrugs(size: 25) { rows { drug { name id } mechanismOfAction phase } } } }"}'
 ```
+
+**Open Targets `knownDrugs` Pagination**:
+- Use `size` parameter only (e.g., `size: 25`) — this is the reliable pattern
+- Do NOT use `page` or `index` — these cause intermittent failures
+- For paginated results, use `cursor` (returned in the response) as the continuation token
+- If first query fails, retry with `size` only (no other pagination params)
 
 **Note**: Requires Ensembl Gene ID (ENSG...). Get this from HGNC cross-references or Ensembl lookup.
 


### PR DESCRIPTION
## Summary

- **P1 fix**: Add `opentargets_get_associations` to ENRICH phase (Phase 2) in graph-builder skill so disease CURIEs (MONDO/EFO) are resolved early enough for TRAVERSE_DRUGS and TRAVERSE_TRIALS to use them
- **P2 fix**: Update Open Targets `knownDrugs` GraphQL pagination to use `size`-only pattern (no `page`/`index`) in both graph-builder and pharmacology skills, avoiding intermittent first-attempt failures

## Test plan

- [ ] Re-run TC2 (ACVR1/FOP) — expect FOP MONDO ID resolved in Phase 2 instead of Phase 3
- [ ] Test Open Targets `knownDrugs` query for ACVR1 — should succeed on first attempt with `size: 25`
- [ ] Verify no regression in TP53/BCL2 and NGLY1 test cases

Addresses issues P1.2 and P2.1 from `docs/retrospectives/skills-rewrite-validation-retrospective.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)